### PR TITLE
Support inherited properties in protobuf generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ var obj = Serializer.Deserialize<MyClass>(new MemoryStream(data));
 - **Partial Classes**: Ensure all protobuf classes are declared as `partial` to allow the source generator to extend
   them.
 
-| Feature         | Protobuf-net Behavior                                                                                                     | LightProto Behavior                     |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
-| Partial Classes | No need                                                                                                                   | must                                    |
-| Inheritance     | [Supported](https://github.com/protobuf-net/protobuf-net?tab=readme-ov-file#inheritance)                                  | Not support                             |
-| Surrogate       | [Supported](https://stackoverflow.com/questions/14796296/serializing-listt-using-a-surrogate-with-protobuf-net-exception) | Supported(see InstrumentProxy in tests) |
+| Feature         | Protobuf-net Behavior                                                                                                     | LightProto Behavior                              |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| Partial Classes | No need                                                                                                                   | must                                             |
+| Inheritance     | [Supported](https://github.com/protobuf-net/protobuf-net?tab=readme-ov-file#inheritance)                                  | Supported out of box                             |
+| Surrogate       | [Supported](https://stackoverflow.com/questions/14796296/serializing-listt-using-a-surrogate-with-protobuf-net-exception) | Supported(ProtoProxyAttribute+ProxyForAttribute) |
 
 If you found any other different behavior with Protobuf-net, please report them via GitHub issues.
 

--- a/src/LightProto.Generator/SimpleProtobufGenerator.cs
+++ b/src/LightProto.Generator/SimpleProtobufGenerator.cs
@@ -148,7 +148,7 @@ public class SimpleProtobufGenerator : ISourceGenerator
               {
                   public static IProtoReader<{{proxyFor?.ToDisplayString()??className}}> Reader {get; } = new ProtoReader();
                   public static IProtoWriter<{{proxyFor?.ToDisplayString()??className}}> Writer {get; } = new ProtoWriter();
-                  public sealed class ProtoWriter:IProtoWriter<{{proxyFor?.ToDisplayString()??className}}>
+                  public sealed new class ProtoWriter:IProtoWriter<{{proxyFor?.ToDisplayString()??className}}>
                   {
                       public bool IsMessage => true;
                       {{string.Join(Environment.NewLine + GetIntendedSpace(2),
@@ -237,7 +237,7 @@ public class SimpleProtobufGenerator : ISourceGenerator
                       }
                   }
                   
-                  public sealed class ProtoReader:IProtoReader<{{proxyFor?.ToDisplayString()??className}}>
+                  public sealed new class ProtoReader:IProtoReader<{{proxyFor?.ToDisplayString()??className}}>
                   {
                       public bool IsMessage => true;
                       {{string.Join(Environment.NewLine + GetIntendedSpace(2),
@@ -970,6 +970,20 @@ public class SimpleProtobufGenerator : ISourceGenerator
     {
         return GetProxyType(type.GetAttributes());
     }
+    
+    IEnumerable<ISymbol> GetAllMembers(INamedTypeSymbol type)
+    {
+        var members = new List<IPropertySymbol>();
+        var currentType = type;
+        while (currentType != null)
+        {
+            members.AddRange(
+                currentType.GetMembers().OfType<IPropertySymbol>().Where(p => !p.IsStatic)
+            );
+            currentType = currentType.BaseType;
+        }
+        return members;
+    }
 
     private List<ProtoMember> GetProtoMembers(
         Compilation compilation,
@@ -979,7 +993,7 @@ public class SimpleProtobufGenerator : ISourceGenerator
     {
         var members = new List<ProtoMember>();
 
-        foreach (var member in targetType.GetMembers())
+        foreach (var member in GetAllMembers(targetType))
         {
             if (!(member is IPropertySymbol property) || property.IsStatic)
                 continue;

--- a/src/LightProto.Generator/SimpleProtobufGenerator.cs
+++ b/src/LightProto.Generator/SimpleProtobufGenerator.cs
@@ -993,10 +993,8 @@ public class SimpleProtobufGenerator : ISourceGenerator
     {
         var members = new List<ProtoMember>();
 
-        foreach (var member in GetAllMembers(targetType))
+        foreach (IPropertySymbol property in GetAllMembers(targetType))
         {
-            if (!(member is IPropertySymbol property) || property.IsStatic)
-                continue;
 
             var propertyDecl = typeDeclaration
                 .Members.OfType<PropertyDeclarationSyntax>()

--- a/src/LightProto.Generator/SimpleProtobufGenerator.cs
+++ b/src/LightProto.Generator/SimpleProtobufGenerator.cs
@@ -971,7 +971,7 @@ public class SimpleProtobufGenerator : ISourceGenerator
         return GetProxyType(type.GetAttributes());
     }
     
-    IEnumerable<ISymbol> GetAllMembers(INamedTypeSymbol type)
+    IEnumerable<IPropertySymbol> GetAllMembers(INamedTypeSymbol type)
     {
         var members = new List<IPropertySymbol>();
         var currentType = type;

--- a/tests/LightProto.Tests/Parsers/Inheritance.cs
+++ b/tests/LightProto.Tests/Parsers/Inheritance.cs
@@ -1,0 +1,19 @@
+﻿namespace LightProto.Tests.Parsers;
+
+public partial class Inheritance
+{
+    [ProtoContract]
+    public partial class Base
+    {
+        [ProtoMember(1)]
+        public string BaseValue { get; set; } = "";
+    }
+
+    [ProtoContract]
+    public partial class Message : Base
+    {
+        [ProtoMember(2)]
+        public string Value { get; set; } = "";
+    }
+    
+}


### PR DESCRIPTION
Refactored SimpleProtobufGenerator to include inherited properties by introducing GetAllMembers, ensuring properties from base classes are processed. Added a test case for inheritance in LightProto.Tests.Parsers.Inheritance.cs. Also updated generated ProtoReader and ProtoWriter classes to use 'new' keyword.