### PR TITLE
Add Field Supported

### DIFF
--- a/tests/LightProto.Tests/Parsers/FieldTests.cs
+++ b/tests/LightProto.Tests/Parsers/FieldTests.cs
@@ -1,0 +1,38 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class FieldTests : BaseTests<FieldTests.Message, StructTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial struct Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public string Property;
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = string.Empty };
+        yield return new() { Property = Guid.NewGuid().ToString("N") };
+    }
+
+    public override IEnumerable<StructTestsMessage> GetGoogleMessages()
+    {
+        yield return new() { Property = string.Empty };
+        yield return new() { Property = Guid.NewGuid().ToString("N") };
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property ?? string.Empty).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertGoogleResult(StructTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property ?? string.Empty).IsEquivalentTo(message.Property);
+    }
+}


### PR DESCRIPTION
Reworked GetProtoMembers to handle both properties and fields, consolidating logic and removing the GetAllMembers helper. Added FieldTests to verify correct parsing and handling of fields in messages.