### PR TITLE
Add support for string interning

### DIFF
--- a/src/LightProto/Attributes.cs
+++ b/src/LightProto/Attributes.cs
@@ -4,8 +4,8 @@ namespace LightProto;
 
 public class ProtoContractAttribute : Attribute
 {
-    [Obsolete("compatibility protobuf-net only, no effect")]
-    public bool SkipConstructor { get; set; } = false;
+    // [Obsolete("compatibility protobuf-net only, no effect")]
+    // public bool SkipConstructor { get; set; } = false;
 }
 
 public class ProtoMemberAttribute(uint tag) : Attribute
@@ -13,14 +13,13 @@ public class ProtoMemberAttribute(uint tag) : Attribute
     public uint Tag { get; } = tag;
     public DataFormat DataFormat { get; set; } = DataFormat.Default;
 
-    [Obsolete("compatibility protobuf-net only, no effect")]
-    public bool IsRequired { get; set; } = false;
+    // [Obsolete("compatibility protobuf-net only, no effect")]
+    // public bool IsRequired { get; set; } = false;
     public bool IsPacked { get; set; } = false;
 
-    [Obsolete("compatibility protobuf-net only, no effect")]
-    public bool OverwriteList { get; set; } = false;
+    // [Obsolete("compatibility protobuf-net only, no effect")]
+    // public bool OverwriteList { get; set; } = false;
 
-    [Obsolete("compatibility protobuf-net only, no effect")]
     public string Name { get; set; } = string.Empty;
 }
 
@@ -37,12 +36,13 @@ public class ProtoProxyAttribute<T> : Attribute;
 
 public class ProtoProxyForAttribute<T> : Attribute;
 
-[Obsolete("compatibility protobuf-net only, no effect")]
-public class ProtoIncludeAttribute(Type type, uint tag) : Attribute
-{
-    public Type Type { get; } = type;
-    public uint Tag { get; } = tag;
-}
+// donot support ProtoInclude for now
+// [Obsolete("compatibility protobuf-net only, no effect")]
+// public class ProtoIncludeAttribute(Type type, uint tag) : Attribute
+// {
+//     public Type Type { get; } = type;
+//     public uint Tag { get; } = tag;
+// }
 
 /// <summary>
 /// Defines the compatibiltiy level to use for an element
@@ -52,11 +52,8 @@ public class ProtoIncludeAttribute(Type type, uint tag) : Attribute
         | AttributeTargets.Module
         | AttributeTargets.Class
         | AttributeTargets.Struct
-        | AttributeTargets.Interface
         | AttributeTargets.Field
-        | AttributeTargets.Property,
-    AllowMultiple = false,
-    Inherited = true
+        | AttributeTargets.Property
 )]
 public sealed class CompatibilityLevelAttribute(CompatibilityLevel level) : Attribute
 {
@@ -66,4 +63,12 @@ public sealed class CompatibilityLevelAttribute(CompatibilityLevel level) : Attr
     public CompatibilityLevel Level { get; } = level;
 }
 
-public sealed class IncludeDateTimeKindAttribute() : Attribute;
+[AttributeUsage(
+    AttributeTargets.Assembly
+        | AttributeTargets.Module
+        | AttributeTargets.Class
+        | AttributeTargets.Struct
+        | AttributeTargets.Field
+        | AttributeTargets.Property
+)]
+public sealed class StringInternAttribute : Attribute;

--- a/src/LightProto/Parser/InternedString.cs
+++ b/src/LightProto/Parser/InternedString.cs
@@ -1,0 +1,20 @@
+﻿namespace LightProto.Parser;
+
+public sealed class InternedStringProtoReader : IProtoReader<string>
+{
+    public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
+    )]
+    public string ParseFrom(ref ReaderContext input)
+    {
+        return string.Intern(input.ReadString());
+    }
+}
+
+public sealed class InternedStringProtoParser : IProtoParser<string>
+{
+    public static IProtoReader<string> Reader { get; } = new InternedStringProtoReader();
+    public static IProtoWriter<string> Writer { get; } = new StringProtoWriter();
+}

--- a/tests/LightProto.Tests/Parsers/InternStringTests.cs
+++ b/tests/LightProto.Tests/Parsers/InternStringTests.cs
@@ -1,0 +1,43 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class InternStringTests
+    : BaseEquivalentTypeTests<
+        InternStringTests.LightProtoMessage,
+        InternStringTests.ProtoBufMessage
+    >
+{
+    [ProtoContract]
+    public partial struct LightProtoMessage
+    {
+        [ProtoMember(1)]
+        [StringIntern]
+        public string Property;
+    }
+
+    [ProtoBuf.ProtoContract]
+    public partial struct ProtoBufMessage
+    {
+        [ProtoBuf.ProtoMember(1)]
+        public string Property;
+    }
+
+    public override IEnumerable<LightProtoMessage> GetLightProtoMessages()
+    {
+        yield return new() { Property = string.Empty };
+        yield return new() { Property = string.Intern(Guid.NewGuid().ToString("N")) };
+    }
+
+    public override IEnumerable<ProtoBufMessage> GetProtoNetMessages()
+    {
+        yield return new() { Property = string.Empty };
+        yield return new() { Property = Guid.NewGuid().ToString("N") };
+    }
+
+    public override async Task AssertResult(LightProtoMessage clone, ProtoBufMessage message)
+    {
+        await Assert.That(String.IsInterned(clone.Property)).IsEquivalentTo(clone.Property);
+    }
+}


### PR DESCRIPTION
Introduces the StringInternAttribute to enable string interning for serialization. Updates generator logic to handle interned strings, adds InternedStringProtoReader/Parser, and provides tests to verify interned string behavior. Cleans up obsolete attributes and comments in Attributes.cs.