### PR TITLE
Add tag verification step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Introduces a step to ensure that the tag being published is based on the main branch. The workflow will fail if the tag does not point to a commit that is an ancestor of origin/main, helping maintain release integrity.