### PR TITLE
Add benchmark run and PR comment to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   linux-test:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,7 +35,17 @@ jobs:
           
           dotnet publish tests/LightProto.Tests/ -f net9.0 -r linux-x64 -c Release
           ./tests/LightProto.Tests/bin/Release/net9.0/linux-x64/publish/LightProto.Tests
-
+          
+      - name: Run Benchmarks
+        run: |
+          dotnet run -c Release --project ./tests/Benchmark -- --filter "*" --exporters github --artifacts ./BenchmarkResults
+          cat ./BenchmarkResults/**/*.md >> $GITHUB_STEP_SUMMARY        
+        
+      - name: Post benchmark result as PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+         path: ./BenchmarkResults/results/*.md
+      
       - name: Test package creation
         run: |
           dotnet pack --configuration Release --output ./test-packages src/LightProto/

--- a/tests/Benchmark/Program.cs
+++ b/tests/Benchmark/Program.cs
@@ -3,14 +3,14 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using LightProto;
 
-// BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-// return;
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+return;
 
 // BenchmarkRunner.Run<Serialize>();
 // return;
-
-BenchmarkRunner.Run<Deserialize>();
-return;
+//
+// BenchmarkRunner.Run<Deserialize>();
+// return;
 
 // var serialize = new Serialize();
 // for (int i = 0; i < 5000; i++)


### PR DESCRIPTION
The CI workflow now runs benchmarks, exports results, and posts them as pull request comments using marocchino/sticky-pull-request-comment. Also, the Benchmark program entry point is updated to run all benchmarks via BenchmarkSwitcher.