### PR TITLE
Remove IProtoMessage interface and update constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
 
 **This project is under active development and may introduce breaking changes. use it in production at your own risk.**
 
-Todo list:
-
-- [ ] Add more tests for other possible types supported by Protobuf-net
-- [ ] Add more benchmarks and performance tests
-- [ ] Improve documentation and examples
-
 ## Quick Start
 
 ```bash
@@ -123,11 +117,11 @@ Here are some known differences between LightProto and Protobuf-net. The goal is
 There is no need to mark your classes as `partial` in Protobuf-net, but LightProto requires it to generate the necessary
 serialization code at compile time.
 
-### Inheritance
+### Generic Serialize / Deserialize Methods
 
-Protobuf-net requires the use of the `[ProtoInclude]` attribute to handle inheritance, This a really complex and not common feature, so LightProto does not support it currently. 
+LightProto does not support `Serialize<int>`,`Deserialize<int>` generic methods. The type parameter must be IProto,
 
-If you need this feature, please let me known.
+```diff
 
 ### IExtensible
 

--- a/src/LightProto.Generator/LightProtoGenerator.cs
+++ b/src/LightProto.Generator/LightProtoGenerator.cs
@@ -177,7 +177,7 @@ public class LightProtoGenerator : ISourceGenerator
                   {{showFiledNumber}}
                   /// </summary>
                   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
-                  {{typeDeclarationString}} {{className}} :{{(proxyFor is null ?$"IProtoMessage<{className}>":$"IProtoParser<{proxyFor.ToDisplayString()}>")}}
+                  {{typeDeclarationString}} {{className}} :{{(proxyFor is null ?$"IProtoParser<{className}>":$"IProtoParser<{proxyFor.ToDisplayString()}>")}}
                   {
                       public static new IProtoReader<{{proxyFor?.ToDisplayString()??className}}> Reader => {{targetType.BaseType}}.{{className}}Reader;
                       public static new IProtoWriter<{{proxyFor?.ToDisplayString()??className}}> Writer => {{targetType.BaseType}}.Writer;
@@ -419,7 +419,7 @@ public class LightProtoGenerator : ISourceGenerator
                   {{showFiledNumber}}
                   /// </summary>
                   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
-                  {{typeDeclarationString}} {{className}} :{{(proxyFor is null ?$"IProtoMessage<{className}>":$"IProtoParser<{proxyFor.ToDisplayString()}>")}}
+                  {{typeDeclarationString}} {{className}} :{{(proxyFor is null ?$"IProtoParser<{className}>":$"IProtoParser<{proxyFor.ToDisplayString()}>")}}
                   {
                       public static IProtoReader<{{proxyFor?.ToDisplayString()??className}}> Reader {get; } = new ProtoReader();
                       public static IProtoWriter<{{proxyFor?.ToDisplayString()??className}}> Writer {get; } = new ProtoWriter();

--- a/src/LightProto/IProtoParser.cs
+++ b/src/LightProto/IProtoParser.cs
@@ -6,9 +6,6 @@ public interface IProtoParser<T>
     public static abstract IProtoWriter<T> Writer { get; }
 }
 
-public interface IProtoMessage<T> : IProtoParser<T>
-    where T : IProtoParser<T>;
-
 public interface IProtoReader<out T>
 {
     public WireFormat.WireType WireType { get; }

--- a/src/LightProto/Serializer.Extensions.cs
+++ b/src/LightProto/Serializer.Extensions.cs
@@ -6,7 +6,7 @@ namespace LightProto;
 public static partial class Serializer
 {
     public static int CalculateSize<T>(this T message)
-        where T : IProtoMessage<T>
+        where T : IProtoParser<T>
     {
         return T.Writer.CalculateSize(message);
     }

--- a/tests/LightProto.Tests/IntergrationTests.cs
+++ b/tests/LightProto.Tests/IntergrationTests.cs
@@ -137,7 +137,7 @@ public class IntergrationTests
         Func<byte[], T2> parserFunc,
         Func<T2, byte[]> t2ToByteArray
     )
-        where T1 : IProtoMessage<T1>
+        where T1 : IProtoParser<T1>
     {
         var bytes = origin.ToByteArray();
         var parsed = parserFunc(bytes);

--- a/tests/LightProto.Tests/Parsers/BaseTests.cs
+++ b/tests/LightProto.Tests/Parsers/BaseTests.cs
@@ -9,7 +9,7 @@ public abstract class BaseTests<
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Message,
     GoogleProtobufMessage
 > : BaseProtoBufTests<Message>
-    where Message : IProtoMessage<Message>
+    where Message : IProtoParser<Message>
     where GoogleProtobufMessage : IMessage<GoogleProtobufMessage>, new()
 {
     public abstract IEnumerable<GoogleProtobufMessage> GetGoogleMessages();
@@ -42,7 +42,7 @@ public abstract class BaseTests<
 public abstract class BaseProtoBufTests<
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Message
 >
-    where Message : IProtoMessage<Message>
+    where Message : IProtoParser<Message>
 {
     public abstract IEnumerable<Message> GetMessages();
 
@@ -103,7 +103,7 @@ public abstract class BaseEquivalentTypeTests<
     LightProtoMessage,
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] ProtoNetMessage
 >
-    where LightProtoMessage : IProtoMessage<LightProtoMessage>
+    where LightProtoMessage : IProtoParser<LightProtoMessage>
 {
     public abstract IEnumerable<LightProtoMessage> GetLightProtoMessages();
     public abstract IEnumerable<ProtoNetMessage> GetProtoNetMessages();


### PR DESCRIPTION
Eliminated the IProtoMessage<T> interface and replaced all type constraints and usages with IProtoParser<T>. Updated generator, serializer extension, and test files to reflect this change, simplifying the type hierarchy and usage.