### PR TITLE
Rename Reader/Writer to ProtoReader/ProtoWriter

### DIFF
--- a/src/LightProto/IProtoParser.cs
+++ b/src/LightProto/IProtoParser.cs
@@ -2,8 +2,8 @@
 
 public interface IProtoParser<T>
 {
-    public static abstract IProtoReader<T> Reader { get; }
-    public static abstract IProtoWriter<T> Writer { get; }
+    public static abstract IProtoReader<T> ProtoReader { get; }
+    public static abstract IProtoWriter<T> ProtoWriter { get; }
 }
 
 public interface IProtoReader<out T>

--- a/src/LightProto/LightProto.csproj
+++ b/src/LightProto/LightProto.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
+    <LangVersion>preview</LangVersion>
     <!-- NuGet Package Metadata -->
     <PackageId>LightProto</PackageId>
     <Title>LightProto.Extension - Generic Protobuf Deserialization</Title>

--- a/src/LightProto/LightProto.csproj
+++ b/src/LightProto/LightProto.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsAotCompatible>true</IsAotCompatible>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
     <!-- NuGet Package Metadata -->
     <PackageId>LightProto</PackageId>
     <Title>LightProto.Extension - Generic Protobuf Deserialization</Title>

--- a/src/LightProto/Parser/Bool.cs
+++ b/src/LightProto/Parser/Bool.cs
@@ -27,6 +27,6 @@ public sealed class BooleanProtoWriter : IProtoWriter<bool>
 
 public sealed class BooleanProtoParser : IProtoParser<bool>
 {
-    public static IProtoReader<bool> Reader { get; } = new BooleanProtoReader();
-    public static IProtoWriter<bool> Writer { get; } = new BooleanProtoWriter();
+    public static IProtoReader<bool> ProtoReader { get; } = new BooleanProtoReader();
+    public static IProtoWriter<bool> ProtoWriter { get; } = new BooleanProtoWriter();
 }

--- a/src/LightProto/Parser/ByteArray.cs
+++ b/src/LightProto/Parser/ByteArray.cs
@@ -32,6 +32,6 @@ public sealed class ByteArrayProtoWriter : IProtoWriter<byte[]>
 
 public sealed class ByteArrayProtoParser : IProtoParser<byte[]>
 {
-    public static IProtoReader<byte[]> Reader { get; } = new ByteArrayProtoReader();
-    public static IProtoWriter<byte[]> Writer { get; } = new ByteArrayProtoWriter();
+    public static IProtoReader<byte[]> ProtoReader { get; } = new ByteArrayProtoReader();
+    public static IProtoWriter<byte[]> ProtoWriter { get; } = new ByteArrayProtoWriter();
 }

--- a/src/LightProto/Parser/ByteList.cs
+++ b/src/LightProto/Parser/ByteList.cs
@@ -38,6 +38,6 @@ public sealed class ByteListProtoWriter : IProtoWriter<List<byte>>
 
 public sealed class ByteListProtoParser : IProtoParser<List<byte>>
 {
-    public static IProtoReader<List<byte>> Reader { get; } = new ByteListProtoReader();
-    public static IProtoWriter<List<byte>> Writer { get; } = new ByteListProtoWriter();
+    public static IProtoReader<List<byte>> ProtoReader { get; } = new ByteListProtoReader();
+    public static IProtoWriter<List<byte>> ProtoWriter { get; } = new ByteListProtoWriter();
 }

--- a/src/LightProto/Parser/DateOnly.cs
+++ b/src/LightProto/Parser/DateOnly.cs
@@ -30,6 +30,6 @@ public sealed class DateOnlyProtoWriter : IProtoWriter<DateOnly>
 
 public sealed class DateOnlyProtoParser : IProtoParser<DateOnly>
 {
-    public static IProtoReader<DateOnly> Reader { get; } = new DateOnlyProtoReader();
-    public static IProtoWriter<DateOnly> Writer { get; } = new DateOnlyProtoWriter();
+    public static IProtoReader<DateOnly> ProtoReader { get; } = new DateOnlyProtoReader();
+    public static IProtoWriter<DateOnly> ProtoWriter { get; } = new DateOnlyProtoWriter();
 }

--- a/src/LightProto/Parser/Decimal300.cs
+++ b/src/LightProto/Parser/Decimal300.cs
@@ -31,6 +31,6 @@ public sealed class Decimal300ProtoWriter : IProtoWriter<Decimal>
 
 public sealed class Decimal300ProtoParser : IProtoParser<Decimal>
 {
-    public static IProtoReader<Decimal> Reader { get; } = new Decimal300ProtoReader();
-    public static IProtoWriter<Decimal> Writer { get; } = new Decimal300ProtoWriter();
+    public static IProtoReader<Decimal> ProtoReader { get; } = new Decimal300ProtoReader();
+    public static IProtoWriter<Decimal> ProtoWriter { get; } = new Decimal300ProtoWriter();
 }

--- a/src/LightProto/Parser/Double.cs
+++ b/src/LightProto/Parser/Double.cs
@@ -36,6 +36,6 @@ public sealed class DoubleProtoWriter : IProtoWriter<Double>
 
 public sealed class DoubleProtoParser : IProtoParser<Double>
 {
-    public static IProtoReader<Double> Reader { get; } = new DoubleProtoReader();
-    public static IProtoWriter<Double> Writer { get; } = new DoubleProtoWriter();
+    public static IProtoReader<Double> ProtoReader { get; } = new DoubleProtoReader();
+    public static IProtoWriter<Double> ProtoWriter { get; } = new DoubleProtoWriter();
 }

--- a/src/LightProto/Parser/Enum.cs
+++ b/src/LightProto/Parser/Enum.cs
@@ -42,6 +42,6 @@ public sealed class EnumProtoWriter<T> : IProtoWriter<T>
 public sealed class EnumProtoParser<T> : IProtoParser<T>
     where T : Enum
 {
-    public static IProtoReader<T> Reader { get; } = new EnumProtoReader<T>();
-    public static IProtoWriter<T> Writer { get; } = new EnumProtoWriter<T>();
+    public static IProtoReader<T> ProtoReader { get; } = new EnumProtoReader<T>();
+    public static IProtoWriter<T> ProtoWriter { get; } = new EnumProtoWriter<T>();
 }

--- a/src/LightProto/Parser/FixedInt32.cs
+++ b/src/LightProto/Parser/FixedInt32.cs
@@ -36,6 +36,6 @@ public sealed class Fixed32ProtoWriter : IProtoWriter<UInt32>
 
 public sealed class Fixed32ProtoParser : IProtoParser<UInt32>
 {
-    public static IProtoReader<UInt32> Reader { get; } = new Fixed32ProtoReader();
-    public static IProtoWriter<UInt32> Writer { get; } = new Fixed32ProtoWriter();
+    public static IProtoReader<UInt32> ProtoReader { get; } = new Fixed32ProtoReader();
+    public static IProtoWriter<UInt32> ProtoWriter { get; } = new Fixed32ProtoWriter();
 }

--- a/src/LightProto/Parser/FixedInt64.cs
+++ b/src/LightProto/Parser/FixedInt64.cs
@@ -36,6 +36,6 @@ public sealed class Fixed64ProtoWriter : IProtoWriter<UInt64>
 
 public sealed class Fixed64ProtoParser : IProtoParser<UInt64>
 {
-    public static IProtoReader<UInt64> Reader { get; } = new Fixed64ProtoReader();
-    public static IProtoWriter<UInt64> Writer { get; } = new Fixed64ProtoWriter();
+    public static IProtoReader<UInt64> ProtoReader { get; } = new Fixed64ProtoReader();
+    public static IProtoWriter<UInt64> ProtoWriter { get; } = new Fixed64ProtoWriter();
 }

--- a/src/LightProto/Parser/Guid300.cs
+++ b/src/LightProto/Parser/Guid300.cs
@@ -30,6 +30,6 @@ public sealed class Guid300ProtoWriter : IProtoWriter<Guid>
 
 public sealed class Guid300ProtoParser : IProtoParser<Guid>
 {
-    public static IProtoReader<Guid> Reader { get; } = new Guid300ProtoReader();
-    public static IProtoWriter<Guid> Writer { get; } = new Guid300ProtoWriter();
+    public static IProtoReader<Guid> ProtoReader { get; } = new Guid300ProtoReader();
+    public static IProtoWriter<Guid> ProtoWriter { get; } = new Guid300ProtoWriter();
 }

--- a/src/LightProto/Parser/Int32.cs
+++ b/src/LightProto/Parser/Int32.cs
@@ -36,6 +36,6 @@ public sealed class Int32ProtoWriter : IProtoWriter<int>
 
 public sealed class Int32ProtoParser : IProtoParser<int>
 {
-    public static IProtoReader<int> Reader { get; } = new Int32ProtoReader();
-    public static IProtoWriter<int> Writer { get; } = new Int32ProtoWriter();
+    public static IProtoReader<int> ProtoReader { get; } = new Int32ProtoReader();
+    public static IProtoWriter<int> ProtoWriter { get; } = new Int32ProtoWriter();
 }

--- a/src/LightProto/Parser/Int64.cs
+++ b/src/LightProto/Parser/Int64.cs
@@ -36,6 +36,6 @@ public sealed class Int64ProtoWriter : IProtoWriter<Int64>
 
 public sealed class Int64ProtoParser : IProtoParser<Int64>
 {
-    public static IProtoReader<Int64> Reader { get; } = new Int64ProtoReader();
-    public static IProtoWriter<Int64> Writer { get; } = new Int64ProtoWriter();
+    public static IProtoReader<Int64> ProtoReader { get; } = new Int64ProtoReader();
+    public static IProtoWriter<Int64> ProtoWriter { get; } = new Int64ProtoWriter();
 }

--- a/src/LightProto/Parser/InternedString.cs
+++ b/src/LightProto/Parser/InternedString.cs
@@ -15,6 +15,6 @@ public sealed class InternedStringProtoReader : IProtoReader<string>
 
 public sealed class InternedStringProtoParser : IProtoParser<string>
 {
-    public static IProtoReader<string> Reader { get; } = new InternedStringProtoReader();
-    public static IProtoWriter<string> Writer { get; } = new StringProtoWriter();
+    public static IProtoReader<string> ProtoReader { get; } = new InternedStringProtoReader();
+    public static IProtoWriter<string> ProtoWriter { get; } = new StringProtoWriter();
 }

--- a/src/LightProto/Parser/SFixed32.cs
+++ b/src/LightProto/Parser/SFixed32.cs
@@ -36,6 +36,6 @@ public sealed class SFixed32ProtoWriter : IProtoWriter<int>
 
 public sealed class SFixed32ProtoParser : IProtoParser<int>
 {
-    public static IProtoReader<int> Reader { get; } = new SFixed32ProtoReader();
-    public static IProtoWriter<int> Writer { get; } = new SFixed32ProtoWriter();
+    public static IProtoReader<int> ProtoReader { get; } = new SFixed32ProtoReader();
+    public static IProtoWriter<int> ProtoWriter { get; } = new SFixed32ProtoWriter();
 }

--- a/src/LightProto/Parser/SFixed64.cs
+++ b/src/LightProto/Parser/SFixed64.cs
@@ -36,6 +36,6 @@ public sealed class SFixed64ProtoWriter : IProtoWriter<Int64>
 
 public sealed class SFixed64ProtoParser : IProtoParser<Int64>
 {
-    public static IProtoReader<Int64> Reader { get; } = new SFixed64ProtoReader();
-    public static IProtoWriter<Int64> Writer { get; } = new SFixed64ProtoWriter();
+    public static IProtoReader<Int64> ProtoReader { get; } = new SFixed64ProtoReader();
+    public static IProtoWriter<Int64> ProtoWriter { get; } = new SFixed64ProtoWriter();
 }

--- a/src/LightProto/Parser/SInt32.cs
+++ b/src/LightProto/Parser/SInt32.cs
@@ -36,6 +36,6 @@ public sealed class SInt32ProtoWriter : IProtoWriter<Int32>
 
 public sealed class SInt32ProtoParser : IProtoParser<Int32>
 {
-    public static IProtoReader<Int32> Reader { get; } = new SInt32ProtoReader();
-    public static IProtoWriter<Int32> Writer { get; } = new SInt32ProtoWriter();
+    public static IProtoReader<Int32> ProtoReader { get; } = new SInt32ProtoReader();
+    public static IProtoWriter<Int32> ProtoWriter { get; } = new SInt32ProtoWriter();
 }

--- a/src/LightProto/Parser/SInt64.cs
+++ b/src/LightProto/Parser/SInt64.cs
@@ -36,6 +36,6 @@ public sealed class SInt64ProtoWriter : IProtoWriter<Int64>
 
 public sealed class SInt64ProtoParser : IProtoParser<Int64>
 {
-    public static IProtoReader<Int64> Reader { get; } = new SInt64ProtoReader();
-    public static IProtoWriter<Int64> Writer { get; } = new SInt64ProtoWriter();
+    public static IProtoReader<Int64> ProtoReader { get; } = new SInt64ProtoReader();
+    public static IProtoWriter<Int64> ProtoWriter { get; } = new SInt64ProtoWriter();
 }

--- a/src/LightProto/Parser/Single.cs
+++ b/src/LightProto/Parser/Single.cs
@@ -36,6 +36,6 @@ public sealed class SingleProtoWriter : IProtoWriter<Single>
 
 public sealed class SingleProtoParser : IProtoParser<Single>
 {
-    public static IProtoReader<Single> Reader { get; } = new SingleProtoReader();
-    public static IProtoWriter<Single> Writer { get; } = new SingleProtoWriter();
+    public static IProtoReader<Single> ProtoReader { get; } = new SingleProtoReader();
+    public static IProtoWriter<Single> ProtoWriter { get; } = new SingleProtoWriter();
 }

--- a/src/LightProto/Parser/String.cs
+++ b/src/LightProto/Parser/String.cs
@@ -36,6 +36,6 @@ public sealed class StringProtoWriter : IProtoWriter<string>
 
 public sealed class StringProtoParser : IProtoParser<string>
 {
-    public static IProtoReader<string> Reader { get; } = new StringProtoReader();
-    public static IProtoWriter<string> Writer { get; } = new StringProtoWriter();
+    public static IProtoReader<string> ProtoReader { get; } = new StringProtoReader();
+    public static IProtoWriter<string> ProtoWriter { get; } = new StringProtoWriter();
 }

--- a/src/LightProto/Parser/StringBuilder.cs
+++ b/src/LightProto/Parser/StringBuilder.cs
@@ -35,6 +35,6 @@ public sealed class StringBuilderProtoWriter : IProtoWriter<StringBuilder>
 
 public sealed class StringBuilderProtoParser : IProtoParser<StringBuilder>
 {
-    public static IProtoReader<StringBuilder> Reader { get; } = new StringBuilderProtoReader();
-    public static IProtoWriter<StringBuilder> Writer { get; } = new StringBuilderProtoWriter();
+    public static IProtoReader<StringBuilder> ProtoReader { get; } = new StringBuilderProtoReader();
+    public static IProtoWriter<StringBuilder> ProtoWriter { get; } = new StringBuilderProtoWriter();
 }

--- a/src/LightProto/Parser/TimeOnly.cs
+++ b/src/LightProto/Parser/TimeOnly.cs
@@ -27,6 +27,6 @@ public sealed class TimeOnlyProtoWriter : IProtoWriter<TimeOnly>
 
 public sealed class TimeOnlyProtoParser : IProtoParser<TimeOnly>
 {
-    public static IProtoReader<TimeOnly> Reader { get; } = new TimeOnlyProtoReader();
-    public static IProtoWriter<TimeOnly> Writer { get; } = new TimeOnlyProtoWriter();
+    public static IProtoReader<TimeOnly> ProtoReader { get; } = new TimeOnlyProtoReader();
+    public static IProtoWriter<TimeOnly> ProtoWriter { get; } = new TimeOnlyProtoWriter();
 }

--- a/src/LightProto/Parser/UInt32.cs
+++ b/src/LightProto/Parser/UInt32.cs
@@ -27,6 +27,6 @@ public sealed class UInt32ProtoWriter : IProtoWriter<UInt32>
 
 public sealed class UInt32ProtoParser : IProtoParser<UInt32>
 {
-    public static IProtoReader<UInt32> Reader { get; } = new UInt32ProtoReader();
-    public static IProtoWriter<UInt32> Writer { get; } = new UInt32ProtoWriter();
+    public static IProtoReader<UInt32> ProtoReader { get; } = new UInt32ProtoReader();
+    public static IProtoWriter<UInt32> ProtoWriter { get; } = new UInt32ProtoWriter();
 }

--- a/src/LightProto/Parser/UInt64.cs
+++ b/src/LightProto/Parser/UInt64.cs
@@ -27,6 +27,6 @@ public sealed class UInt64ProtoWriter : IProtoWriter<UInt64>
 
 public sealed class UInt64ProtoParser : IProtoParser<UInt64>
 {
-    public static IProtoReader<UInt64> Reader { get; } = new UInt64ProtoReader();
-    public static IProtoWriter<UInt64> Writer { get; } = new UInt64ProtoWriter();
+    public static IProtoReader<UInt64> ProtoReader { get; } = new UInt64ProtoReader();
+    public static IProtoWriter<UInt64> ProtoWriter { get; } = new UInt64ProtoWriter();
 }

--- a/src/LightProto/Serializer.Collection.Deserializer.cs
+++ b/src/LightProto/Serializer.Collection.Deserializer.cs
@@ -12,21 +12,24 @@ public static partial class Serializer
     /// <returns>A new, initialized instance.</returns>
     public static TCollection Deserialize<TCollection, TItem>(Stream source)
         where TCollection : ICollection<TItem>, new()
-        where TItem : IProtoParser<TItem> => Deserialize<TCollection, TItem>(source, TItem.Reader);
+        where TItem : IProtoParser<TItem> =>
+        Deserialize<TCollection, TItem>(source, TItem.ProtoReader);
 
     /// <summary>
     /// Creates a new instance from a protocol-buffer stream
     /// </summary>
     public static TCollection Deserialize<TCollection, TItem>(ReadOnlySequence<byte> source)
         where TCollection : ICollection<TItem>, new()
-        where TItem : IProtoParser<TItem> => Deserialize<TCollection, TItem>(source, TItem.Reader);
+        where TItem : IProtoParser<TItem> =>
+        Deserialize<TCollection, TItem>(source, TItem.ProtoReader);
 
     /// <summary>
     /// Creates a new instance from a protocol-buffer stream
     /// </summary>
     public static TCollection Deserialize<TCollection, TItem>(ReadOnlySpan<byte> source)
         where TCollection : ICollection<TItem>, new()
-        where TItem : IProtoParser<TItem> => Deserialize<TCollection, TItem>(source, TItem.Reader);
+        where TItem : IProtoParser<TItem> =>
+        Deserialize<TCollection, TItem>(source, TItem.ProtoReader);
 
     /// <summary>
     /// Creates a new instance from a protocol-buffer stream

--- a/src/LightProto/Serializer.Collection.Serializer.cs
+++ b/src/LightProto/Serializer.Collection.Serializer.cs
@@ -11,7 +11,7 @@ public static partial class Serializer
     /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
     /// <param name="destination">The destination stream to write to.</param>
     public static void Serialize<T>(Stream destination, ICollection<T> instance)
-        where T : IProtoParser<T> => Serialize(destination, instance, T.Writer);
+        where T : IProtoParser<T> => Serialize(destination, instance, T.ProtoWriter);
 
     /// <summary>
     /// Writes a protocol-buffer representation of the given instance to the supplied writer.
@@ -19,7 +19,7 @@ public static partial class Serializer
     /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
     /// <param name="destination">The destination stream to write to.</param>
     public static void Serialize<T>(IBufferWriter<byte> destination, ICollection<T> instance)
-        where T : IProtoParser<T> => Serialize(destination, instance, T.Writer);
+        where T : IProtoParser<T> => Serialize(destination, instance, T.ProtoWriter);
 
     /// <summary>
     /// Writes a protocol-buffer representation of the given instance to the supplied writer.

--- a/src/LightProto/Serializer.Deserialize.cs
+++ b/src/LightProto/Serializer.Deserialize.cs
@@ -11,19 +11,19 @@ public static partial class Serializer
     /// <param name="source">The binary stream to apply to the new instance (cannot be null).</param>
     /// <returns>A new, initialized instance.</returns>
     public static T Deserialize<T>(Stream source)
-        where T : IProtoParser<T> => Deserialize(source, T.Reader);
+        where T : IProtoParser<T> => Deserialize(source, T.ProtoReader);
 
     /// <summary>
     /// Creates a new instance from a protocol-buffer stream
     /// </summary>
     public static T Deserialize<T>(ReadOnlySequence<byte> source)
-        where T : IProtoParser<T> => Deserialize(source, T.Reader);
+        where T : IProtoParser<T> => Deserialize(source, T.ProtoReader);
 
     /// <summary>
     /// Creates a new instance from a protocol-buffer stream
     /// </summary>
     public static T Deserialize<T>(ReadOnlySpan<byte> source)
-        where T : IProtoParser<T> => Deserialize(source, T.Reader);
+        where T : IProtoParser<T> => Deserialize(source, T.ProtoReader);
 
     /// <summary>
     /// Creates a new instance from a protocol-buffer stream

--- a/src/LightProto/Serializer.Extensions.cs
+++ b/src/LightProto/Serializer.Extensions.cs
@@ -8,7 +8,7 @@ public static partial class Serializer
     public static int CalculateSize<T>(this T message)
         where T : IProtoParser<T>
     {
-        return T.Writer.CalculateSize(message);
+        return T.ProtoWriter.CalculateSize(message);
     }
 
     public static int CalculateMessageSize<T>(this IProtoWriter<T> writer, T value)
@@ -103,7 +103,7 @@ public static partial class Serializer
     public static byte[] ToByteArray<T>(this T message)
         where T : IProtoParser<T>
     {
-        return ToByteArray(message, T.Writer);
+        return ToByteArray(message, T.ProtoWriter);
     }
 
     public static byte[] ToByteArray<T>(this ICollection<T> message, IProtoWriter<T> writer)
@@ -114,7 +114,7 @@ public static partial class Serializer
     public static byte[] ToByteArray<T>(this ICollection<T> message)
         where T : IProtoParser<T>
     {
-        return ToByteArray(message, T.Writer);
+        return ToByteArray(message, T.ProtoWriter);
     }
 
     /// <summary>

--- a/src/LightProto/Serializer.Serialize.cs
+++ b/src/LightProto/Serializer.Serialize.cs
@@ -10,7 +10,7 @@ public static partial class Serializer
     /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
     /// <param name="destination">The destination stream to write to.</param>
     public static void Serialize<T>(Stream destination, T instance)
-        where T : IProtoParser<T> => Serialize(destination, instance, T.Writer);
+        where T : IProtoParser<T> => Serialize(destination, instance, T.ProtoWriter);
 
     /// <summary>
     /// Writes a protocol-buffer representation of the given instance to the supplied writer.
@@ -18,7 +18,7 @@ public static partial class Serializer
     /// <param name="instance">The existing instance to be serialized (cannot be null).</param>
     /// <param name="destination">The destination stream to write to.</param>
     public static void Serialize<T>(IBufferWriter<byte> destination, T instance)
-        where T : IProtoParser<T> => Serialize(destination, instance, T.Writer);
+        where T : IProtoParser<T> => Serialize(destination, instance, T.ProtoWriter);
 
     /// <summary>
     /// Writes a protocol-buffer representation of the given instance to the supplied writer.
@@ -46,7 +46,7 @@ public static partial class Serializer
     {
         unsafe
         {
-            var size = T.Writer.CalculateSize(message);
+            var size = T.ProtoWriter.CalculateSize(message);
             Span<byte> buffer;
             if (size < 256)
             {
@@ -59,7 +59,7 @@ public static partial class Serializer
                 buffer = new byte[size];
             }
             WriterContext.Initialize(ref buffer, out var ctx);
-            T.Writer.WriteTo(ref ctx, message);
+            T.ProtoWriter.WriteTo(ref ctx, message);
             return Deserialize<T>(buffer);
         }
     }

--- a/tests/LightProto.Tests/CollectionSerializerTest.cs
+++ b/tests/LightProto.Tests/CollectionSerializerTest.cs
@@ -8,8 +8,11 @@ public class CollectionSerializerTest
     public async Task IntListTest()
     {
         List<int> list = [1, 2, 3, 4];
-        var bytes = list.ToByteArray(Int32ProtoParser.Writer);
-        var clone = Serializer.Deserialize<List<int>, int>(bytes.AsSpan(), Int32ProtoParser.Reader);
+        var bytes = list.ToByteArray(Int32ProtoParser.ProtoWriter);
+        var clone = Serializer.Deserialize<List<int>, int>(
+            bytes.AsSpan(),
+            Int32ProtoParser.ProtoReader
+        );
         await Assert.That(clone).IsEquivalentTo(list);
     }
 
@@ -17,11 +20,11 @@ public class CollectionSerializerTest
     public async Task StringListTest()
     {
         List<string> list = ["123", "", "111"];
-        var bytes = list.ToByteArray(StringProtoParser.Writer);
+        var bytes = list.ToByteArray(StringProtoParser.ProtoWriter);
 
         var clone = Serializer.Deserialize<List<string>, string>(
             bytes.AsSpan(),
-            StringProtoParser.Reader
+            StringProtoParser.ProtoReader
         );
         await Assert.That(clone).IsEquivalentTo(list);
     }
@@ -30,12 +33,12 @@ public class CollectionSerializerTest
     public async Task DictionaryTest()
     {
         var map = new Dictionary<string, int>() { ["a"] = 1, ["b"] = 2 };
-        var bytes = map.ToByteArray(StringProtoParser.Writer, Int32ProtoParser.Writer);
+        var bytes = map.ToByteArray(StringProtoParser.ProtoWriter, Int32ProtoParser.ProtoWriter);
 
         var clone = Serializer.Deserialize<Dictionary<string, int>, string, int>(
             bytes.AsSpan(),
-            StringProtoParser.Reader,
-            Int32ProtoParser.Reader
+            StringProtoParser.ProtoReader,
+            Int32ProtoParser.ProtoReader
         );
         await Assert.That(clone).IsEquivalentTo(map);
     }

--- a/tests/LightProto.Tests/IntergrationTests.cs
+++ b/tests/LightProto.Tests/IntergrationTests.cs
@@ -152,7 +152,7 @@ public class IntergrationTests
         await Assert.That(originalBytes).IsEqualTo(parsedBytes);
         await Assert.That(t2Array.Length).IsEqualTo(origin.CalculateSize());
 
-        var parseBack = T1.Reader.ParseFrom(bytes);
+        var parseBack = T1.ProtoReader.ParseFrom(bytes);
         var bytes2 = parseBack.ToByteArray();
 
         var parseBackBytes = Convert.ToHexString(bytes2);
@@ -177,7 +177,7 @@ public class IntergrationTests
         await Assert.That(obj.ConcurrentStringQueueFieldTests).IsNotNull();
         await Assert.That(obj.ConcurrentStringStackFieldTests).IsNotNull();
         var bytes = obj.ToByteArray();
-        var parsed = CsTestMessage.Reader.ParseFrom(bytes);
+        var parsed = CsTestMessage.ProtoReader.ParseFrom(bytes);
         await Assert.That(parsed.Int32ArrayFields).IsNotNull();
         await Assert.That(parsed.StringArrayFields).IsNotNull();
         await Assert.That(parsed.IntListFieldTests).IsNotNull();

--- a/tests/LightProto.Tests/ProxyTests.cs
+++ b/tests/LightProto.Tests/ProxyTests.cs
@@ -8,7 +8,7 @@ public partial class ProxyTests
         ProtoProxy testObj = new() { Instrument = Instrument.FromNameValue("hello", 20) };
 
         var bytes = testObj.ToByteArray();
-        var parsed = ProtoProxy.Reader.ParseFrom(bytes);
+        var parsed = ProtoProxy.ProtoReader.ParseFrom(bytes);
         await Assert.That(parsed.Instrument.Name).IsEqualTo(testObj.Instrument.Name);
         await Assert.That(parsed.Instrument.Value).IsEqualTo(testObj.Instrument.Value);
         //parsed.GetHashCode()await Assert.That().IsEqualTo(testObj.GetHashCode());


### PR DESCRIPTION
Refactored all usages of static Reader and Writer properties in IProtoParser and related classes to ProtoReader and ProtoWriter for clarity and consistency. Updated generator, parser, serializer, and test code to use the new property names. Also set LangVersion to 'preview' in the project file.