### PR TITLE
Improve byte array is empty check and fix related tests

### DIFF
--- a/src/LightProto.Generator/LightProtoGenerator.cs
+++ b/src/LightProto.Generator/LightProtoGenerator.cs
@@ -1157,6 +1157,11 @@ public class LightProtoGenerator : ISourceGenerator
 
     public static bool HasLengthProperty(ITypeSymbol type)
     {
+        if (type.TypeKind == TypeKind.Array)
+        {
+            return true;
+        }
+
         return HasProperty(type, "Length", SpecialType.System_Int32);
     }
 

--- a/tests/LightProto.Tests/LightProto.Tests.csproj
+++ b/tests/LightProto.Tests/LightProto.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.32.0" />
     <PackageReference Include="protobuf-net" Version="3.2.56" />
-    <PackageReference Include="TUnit" Version="0.57.65" />
+    <PackageReference Include="TUnit" Version="0.61.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\LightProto\LightProto.csproj" />

--- a/tests/LightProto.Tests/Parsers/ByteArrayTests.cs
+++ b/tests/LightProto.Tests/Parsers/ByteArrayTests.cs
@@ -1,0 +1,49 @@
+﻿using Google.Protobuf;
+using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ByteArrayTests : BaseTests<ByteArrayTests.Message, ByteArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public byte[] Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property)}";
+        }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new Byte[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new Byte[] { 0, 0, 0, 0, 0 } };
+        yield return new() { Property = new Byte[] { 0 } };
+        yield return new() { Property = [] };
+    }
+
+    public override IEnumerable<ByteArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages()
+            .Select(o => new ByteArrayTestsMessage()
+            {
+                Property = ByteString.CopyFrom(o.Property),
+            });
+    }
+
+    public override async Task AssertGoogleResult(ByteArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToByteArray()).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/parser.proto
+++ b/tests/LightProto.Tests/Parsers/parser.proto
@@ -4,6 +4,9 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 import "protobuf-net/bcl.proto";
 
+message ByteArrayTestsMessage {
+  bytes Property = 1;
+}
 message ArrayTestsMessage {
   repeated int32 Property = 1 [packed = false];
 }


### PR DESCRIPTION
Introduces ByteArrayTests to verify serialization and compatibility for byte[] properties. Updates LightProtoGenerator to correctly identify arrays with a Length property. Adds ByteArrayTestsMessage to parser.proto and improves integration test diagnostics. Also updates TUnit test framework version.