### PR TITLE
Add tests for new parsers and update proto definitions

### DIFF
--- a/tests/LightProto.Tests/IntergrationTests.cs
+++ b/tests/LightProto.Tests/IntergrationTests.cs
@@ -154,7 +154,7 @@ public class IntergrationTests
             await Assert.That(originalBytes).IsEqualTo(parsedBytes);
             await Assert.That(t2Array.Length).IsEqualTo(origin.CalculateSize());
         }
-        catch (Exception e)
+        catch (Exception)
         {
             Console.WriteLine($"original: {JsonSerializer.Serialize(origin)}");
             Console.WriteLine($"parsed: {JsonSerializer.Serialize(parsed)}");

--- a/tests/LightProto.Tests/Parsers/ConcurrentDictionary.cs
+++ b/tests/LightProto.Tests/Parsers/ConcurrentDictionary.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Concurrent;
+using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ConcurrentDictionaryTests
+    : BaseTests<ConcurrentDictionaryTests.Message, MapTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ConcurrentDictionary<int, string> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return string.Join(",", Property.Select(x => $"{x.Key}:{x.Value}"));
+        }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new ConcurrentDictionary<int, string>() };
+        yield return new()
+        {
+            Property = new ConcurrentDictionary<int, string>()
+            {
+                [1] = "one",
+                [2] = "two",
+                [3] = "three",
+            },
+        };
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override IEnumerable<MapTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new MapTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(MapTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+}

--- a/tests/LightProto.Tests/Parsers/DateOnly.cs
+++ b/tests/LightProto.Tests/Parsers/DateOnly.cs
@@ -1,0 +1,39 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class DateOnlyTests : BaseTests<DateOnlyTests.Message, DateOnlyTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public DateOnly Property { get; set; }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = DateOnly.MinValue };
+        yield return new() { Property = DateOnly.MaxValue };
+        yield return new() { Property = DateOnly.FromDateTime(DateTime.Today) };
+    }
+
+    public override IEnumerable<DateOnlyTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages()
+            .Select(o => new DateOnlyTestsMessage() { Property = o.Property.DayNumber });
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertGoogleResult(DateOnlyTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property.DayNumber);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/SortedDictionary.cs
+++ b/tests/LightProto.Tests/Parsers/SortedDictionary.cs
@@ -1,0 +1,51 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class SortedDictionaryTests
+    : BaseTests<SortedDictionaryTests.Message, MapTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public SortedDictionary<int, string> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return string.Join(",", Property.Select(x => $"{x.Key}:{x.Value}"));
+        }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new SortedDictionary<int, string>() };
+        yield return new()
+        {
+            Property = new SortedDictionary<int, string>()
+            {
+                [1] = "one",
+                [2] = "two",
+                [3] = "three",
+            },
+        };
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override IEnumerable<MapTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new MapTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(MapTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+}

--- a/tests/LightProto.Tests/Parsers/SortedList.cs
+++ b/tests/LightProto.Tests/Parsers/SortedList.cs
@@ -1,0 +1,50 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class SortedListTests : BaseTests<SortedListTests.Message, MapTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public SortedList<int, string> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return string.Join(",", Property.Select(x => $"{x.Key}:{x.Value}"));
+        }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new SortedList<int, string>() };
+        yield return new()
+        {
+            Property = new SortedList<int, string>()
+            {
+                [1] = "one",
+                [2] = "two",
+                [3] = "three",
+            },
+        };
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override IEnumerable<MapTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new MapTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(MapTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+}

--- a/tests/LightProto.Tests/Parsers/TimeOnly.cs
+++ b/tests/LightProto.Tests/Parsers/TimeOnly.cs
@@ -1,0 +1,39 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class TimeOnlyTests : BaseTests<TimeOnlyTests.Message, TimeOnlyTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public TimeOnly Property { get; set; }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = TimeOnly.MinValue };
+        yield return new() { Property = TimeOnly.MaxValue };
+        yield return new() { Property = TimeOnly.FromDateTime(DateTime.Today) };
+    }
+
+    public override IEnumerable<TimeOnlyTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages()
+            .Select(o => new TimeOnlyTestsMessage() { Property = o.Property.Ticks });
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertGoogleResult(TimeOnlyTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property.Ticks);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/parser.proto
+++ b/tests/LightProto.Tests/Parsers/parser.proto
@@ -14,6 +14,14 @@ message DateTimeTestsMessage
 {
   bcl.DateTime Property = 1;
 }
+message DateOnlyTestsMessage
+{
+  int32 Property = 1;
+}
+message TimeOnlyTestsMessage
+{
+  int64 Property = 1;
+}
 message DateTime240TestsMessage
 {
   google.protobuf.Timestamp Property = 1;


### PR DESCRIPTION
Added test classes for ConcurrentDictionary, DateOnly, SortedDictionary, SortedList, and TimeOnly parsers. Updated parser.proto to include messages for DateOnly and TimeOnly. Minor exception handling improvement in IntergrationTests.cs.