### PR TITLE
Improve Code Coverage

### DIFF
--- a/src/LightProto.Generator/LightProtoGenerator.cs
+++ b/src/LightProto.Generator/LightProtoGenerator.cs
@@ -577,50 +577,6 @@ public class LightProtoGenerator : ISourceGenerator
                   }
                   """
             );
-
-            string GenSkipConstructor()
-            {
-                return $$"""
-                     var parsed = ({{className}})System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(typeof({{className}}));
-                     {{string.Join(Environment.NewLine + GetIntendedSpace(4),
-                         protoMembers.Select(member => {
-                             if (member.IsReadOnly && (IsCollectionType(compilation, member.Type)||IsDictionaryType(compilation, member.Type)))
-                             {
-                                 throw new LightProtoGeneratorException("Member should not be readonly when SkipConstructor as we can't assign a value to it") { Id = "LIGHT_PROTO_002", Title = $"{member.Name} is readonly", Category = "Usage", Severity = DiagnosticSeverity.Error, Location = member.DeclarationSyntax.GetLocation() };
-                             }
-                             else if (member.IsInitOnly)
-                             {
-                                 throw new LightProtoGeneratorException("Member should not be initonly when SkipConstructor as we can't assign a value to it") { Id = "LIGHT_PROTO_001", Title = $"{member.Name} is InitOnly", Category = "Usage", Severity = DiagnosticSeverity.Error, Location = member.DeclarationSyntax.GetLocation() };
-                             }
-                             else
-                             {
-                                 return $"parsed.{member.Name} = _{member.Name};";
-                             }
-                         }))
-                     }}
-                     """;
-            }
-
-            string GenGeneralConstructor()
-            {
-                return $$"""
-                 var parsed = new {{className}}()
-                 {
-                     {{string.Join(Environment.NewLine + GetIntendedSpace(4),
-                         protoMembers.Select(member => {
-                             if (member.IsReadOnly && (IsCollectionType(compilation, member.Type)||IsDictionaryType(compilation, member.Type)))
-                             {
-                                 return $"// {member.Name} is readonly";
-                             }
-                             else
-                             {
-                                 return $"{member.Name} = _{member.Name},";
-                             }
-                         }))
-                     }}
-                 };
-                 """;
-            }
         }
         else
         {

--- a/src/LightProto/CodedOutputStream.ComputeSize.cs
+++ b/src/LightProto/CodedOutputStream.ComputeSize.cs
@@ -291,16 +291,5 @@ namespace LightProto
             }
             return 10;
         }
-
-        /// <summary>
-        /// Computes the number of bytes that would be needed to encode a tag.
-        /// </summary>
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
-        public static int ComputeTagSize(int fieldNumber)
-        {
-            return ComputeRawVarint32Size(WireFormat.MakeTag(fieldNumber, 0));
-        }
     }
 }

--- a/src/LightProto/CodedOutputStream.cs
+++ b/src/LightProto/CodedOutputStream.cs
@@ -78,23 +78,6 @@ namespace LightProto
         }
 
         /// <summary>
-        /// Creates a new <see cref="CodedOutputStream" /> which write to the given stream, and disposes of that
-        /// stream when the returned <c>CodedOutputStream</c> is disposed.
-        /// </summary>
-        /// <param name="output">The stream to write to. It will be disposed when the returned <c>CodedOutputStream is disposed.</c></param>
-        public CodedOutputStream(Stream output)
-            : this(output, DefaultBufferSize, false) { }
-
-        /// <summary>
-        /// Creates a new CodedOutputStream which write to the given stream and uses
-        /// the specified buffer size.
-        /// </summary>
-        /// <param name="output">The stream to write to. It will be disposed when the returned <c>CodedOutputStream is disposed.</c></param>
-        /// <param name="bufferSize">The size of buffer to use internally.</param>
-        public CodedOutputStream(Stream output, int bufferSize)
-            : this(output, new byte[bufferSize], false) { }
-
-        /// <summary>
         /// Creates a new CodedOutputStream which write to the given stream.
         /// </summary>
         /// <param name="output">The stream to write to.</param>
@@ -114,48 +97,6 @@ namespace LightProto
         public CodedOutputStream(Stream output, int bufferSize, bool leaveOpen)
             : this(output, new byte[bufferSize], leaveOpen) { }
         #endregion
-
-        /// <summary>
-        /// Returns the current position in the stream, or the position in the output buffer
-        /// </summary>
-        public long Position
-        {
-            get
-            {
-                if (output != null)
-                {
-                    return output.Position + state.position;
-                }
-                return state.position;
-            }
-        }
-
-        /// <summary>
-        /// Configures whether or not serialization is deterministic.
-        /// </summary>
-        /// <remarks>
-        /// Deterministic serialization guarantees that for a given binary, equal messages (defined by the
-        /// equals methods in protos) will always be serialized to the same bytes. This implies:
-        /// <list type="bullet">
-        /// <item><description>Repeated serialization of a message will return the same bytes.</description></item>
-        /// <item><description>Different processes of the same binary (which may be executing on different machines)
-        /// will serialize equal messages to the same bytes.</description></item>
-        /// </list>
-        /// Note the deterministic serialization is NOT canonical across languages; it is also unstable
-        /// across different builds with schema changes due to unknown fields. Users who need canonical
-        /// serialization, e.g. persistent storage in a canonical form, fingerprinting, etc, should define
-        /// their own canonicalization specification and implement the serializer using reflection APIs
-        /// rather than relying on this API.
-        /// Once set, the serializer will: (Note this is an implementation detail and may subject to
-        /// change in the future)
-        /// <list type="bullet">
-        /// <item><description>Sort map entries by keys in lexicographical order or numerical order. Note: For string
-        /// keys, the order is based on comparing the UTF-16 code unit value of each character in the strings.
-        /// The order may be different from the deterministic serialization in other languages where
-        /// maps are sorted on the lexicographical order of the UTF8 encoded keys.</description></item>
-        /// </list>
-        /// </remarks>
-        public bool Deterministic { get; set; }
 
         /// <summary>
         /// Indicates that a CodedOutputStream wrapping a flat byte array
@@ -200,23 +141,6 @@ namespace LightProto
             var span = new Span<byte>(buffer);
             WriteBufferHelper.Flush(ref span, ref state);
         }
-
-        /// <summary>
-        /// Verifies that SpaceLeft returns zero. It's common to create a byte array
-        /// that is exactly big enough to hold a message, then write to it with
-        /// a CodedOutputStream. Calling CheckNoSpaceLeft after writing verifies that
-        /// the message was actually as big as expected, which can help finding bugs.
-        /// </summary>
-        public void CheckNoSpaceLeft()
-        {
-            WriteBufferHelper.CheckNoSpaceLeft(ref state);
-        }
-
-        /// <summary>
-        /// If writing to a flat array, returns the space left in the array. Otherwise,
-        /// throws an InvalidOperationException.
-        /// </summary>
-        public int SpaceLeft => WriteBufferHelper.GetSpaceLeft(ref state);
 
         internal byte[] InternalBuffer => buffer;
 

--- a/src/LightProto/InternalVisibleTo.cs
+++ b/src/LightProto/InternalVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿// using System.Runtime.CompilerServices;
+//
+// [assembly:InternalsVisibleTo()]

--- a/src/LightProto/LightProto.csproj
+++ b/src/LightProto/LightProto.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    <InternalsVisibleTo Include="LightProto.Tests" />
     <ProjectReference
       Include="..\LightProto.Generator\LightProto.Generator.csproj"
       OutputItemType="Analyzer"

--- a/src/LightProto/Parser/TimeSpanLevel240.cs
+++ b/src/LightProto/Parser/TimeSpanLevel240.cs
@@ -33,23 +33,6 @@ public sealed partial class TimeSpan240ProtoParser
     internal const int MaxNanoseconds = NanosecondsPerSecond - 1;
     internal const int MinNanoseconds = -NanosecondsPerSecond + 1;
 
-    internal static bool IsNormalized(long seconds, int nanoseconds)
-    {
-        // Simple boundaries
-        if (
-            seconds < MinSeconds
-            || seconds > MaxSeconds
-            || nanoseconds < MinNanoseconds
-            || nanoseconds > MaxNanoseconds
-        )
-        {
-            return false;
-        }
-        // We only have a problem is one is strictly negative and the other is
-        // strictly positive.
-        return Math.Sign(seconds) * Math.Sign(nanoseconds) != -1;
-    }
-
     public static implicit operator TimeSpan(TimeSpan240ProtoParser protoParser)
     {
         checked

--- a/src/LightProto/WriteBufferHelper.cs
+++ b/src/LightProto/WriteBufferHelper.cs
@@ -22,8 +22,6 @@ namespace LightProto
         private IBufferWriter<byte>? bufferWriter;
         private CodedOutputStream? codedOutputStream;
 
-        public CodedOutputStream? CodedOutputStream => codedOutputStream;
-
         /// <summary>
         /// Initialize an instance with a coded output stream.
         /// This approach is faster than using a constructor because the instance to initialize is passed by reference
@@ -66,41 +64,6 @@ namespace LightProto
         {
             instance.bufferWriter = null;
             instance.codedOutputStream = null;
-        }
-
-        /// <summary>
-        /// Verifies that SpaceLeft returns zero.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void CheckNoSpaceLeft(ref WriterInternalState state)
-        {
-            if (GetSpaceLeft(ref state) != 0)
-            {
-                throw new InvalidOperationException("Did not write as much data as expected.");
-            }
-        }
-
-        /// <summary>
-        /// If writing to a flat array, returns the space left in the array. Otherwise,
-        /// throws an InvalidOperationException.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetSpaceLeft(ref WriterInternalState state)
-        {
-            if (
-                state.writeBufferHelper.codedOutputStream?.InternalOutputStream == null
-                && state.writeBufferHelper.bufferWriter == null
-            )
-            {
-                return state.limit - state.position;
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                    "SpaceLeft can only be called on CodedOutputStreams that are "
-                        + "writing to a flat array or when writing to a single span."
-                );
-            }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/LightProto/WriterContext.cs
+++ b/src/LightProto/WriterContext.cs
@@ -194,17 +194,5 @@ namespace LightProto
         public void WriteTag(uint tag) => WritingPrimitives.WriteTag(ref buffer, ref state, tag);
 
         internal void Flush() => WriteBufferHelper.Flush(ref buffer, ref state);
-
-        internal void CheckNoSpaceLeft() => WriteBufferHelper.CheckNoSpaceLeft(ref state);
-
-        internal void CopyStateTo(CodedOutputStream output)
-        {
-            output.InternalState = state;
-        }
-
-        internal void LoadStateFrom(CodedOutputStream output)
-        {
-            state = output.InternalState;
-        }
     }
 }

--- a/src/LightProto/WriterInternalState.cs
+++ b/src/LightProto/WriterInternalState.cs
@@ -19,9 +19,5 @@ namespace LightProto
         internal int position; // position in the current buffer
 
         internal WriteBufferHelper writeBufferHelper;
-
-        // If non-null, the top level parse method was started with given coded output stream as an argument
-        // which also means we can potentially fallback to calling WriteTo(CodedOutputStream cos) if needed.
-        internal CodedOutputStream? CodedOutputStream => writeBufferHelper.CodedOutputStream;
     }
 }

--- a/tests/LightProto.Tests/FailedTests.cs
+++ b/tests/LightProto.Tests/FailedTests.cs
@@ -1,0 +1,192 @@
+﻿using System.Buffers;
+using LightProto.Parser;
+
+namespace LightProto.Tests;
+
+public partial class FailedTests
+{
+    [Test]
+    public async Task Sequence_contained_null_element_WhenSerializing()
+    {
+        List<string> strings = new() { "one", null!, "three" };
+        var ex = await Assert.ThrowsAsync<Exception>(async () =>
+        {
+            var bytes = strings.ToByteArray(StringProtoParser.ProtoWriter);
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).IsEqualTo("Sequence contained null element");
+    }
+
+    [Test]
+    public async Task Sequence_contained_null_element_WhenSerializing2()
+    {
+        HashSet<string> strings = new() { "one", null!, "three" };
+        var ex = await Assert.ThrowsAsync<Exception>(async () =>
+        {
+            var bytes = strings.ToByteArray(StringProtoParser.ProtoWriter);
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).IsEqualTo("Sequence contained null element");
+    }
+
+    [Test]
+    public async Task InvalidTag_WhenDeserializing()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            var bytes = new byte[] { 0, 1, 0 };
+            var strings = Serializer.Deserialize<List<int>, int>(
+                bytes,
+                Int32ProtoParser.ProtoReader
+            );
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("invalid tag");
+    }
+
+    [ProtoContract]
+    public partial class TestContract
+    {
+        [ProtoMember(1)]
+        public TestContract? Object { get; set; }
+
+        [ProtoMember(2)]
+        public int Value { get; set; }
+    }
+
+    [Test]
+    public async Task NegativeSize_WhenDeserializing()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            var bytes = new byte[] { 10, 255, 255, 255, 255, 255, 255, 255, 255, 1, 16, 1 };
+            var strings = Serializer.Deserialize<TestContract>(bytes);
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("have negative size");
+    }
+
+    [Test]
+    public async Task TruncatedMessage_WhenDeserializing()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            var bytes = new byte[] { 8, 1, 8 };
+            var strings = Serializer.Deserialize<List<int>, int>(
+                bytes,
+                Int32ProtoParser.ProtoReader
+            );
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("input has been truncated");
+    }
+
+    [Test]
+    public async Task InvalidUtf8_WhenDeserializing()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            // normal bytes is new byte[] { 10,3,111,110,111,10,5,116,104,114,101,101 };
+            var bytes = new byte[] { 10, 3, 0xE0, 0x80, 0x80, 10, 5, 116, 104, 114, 101, 101 };
+            var strings = Serializer.Deserialize<List<string>, string>(
+                bytes,
+                StringProtoParser.ProtoReader
+            );
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("is invalid UTF-8");
+    }
+
+    [Test]
+    public async Task RecursionLimitExceeded_WhenDeserializing()
+    {
+        var bytes = new TestContract()
+        {
+            Object = new TestContract()
+            {
+                Value = 1,
+                Object = new TestContract() { Object = new TestContract() { Value = 1 } },
+            },
+        }.ToByteArray(); //10,8,10,4,10,2,16,1,16,1
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            var bytes = new byte[] { 10, 8, 10, 4, 10, 2, 16, 1, 16, 1 };
+            var obj = Parse(bytes);
+            static TestContract Parse(byte[] bytes)
+            {
+                ReaderContext.Initialize(bytes, out var ctx);
+                ctx.state.recursionLimit = 2;
+                return TestContract.ProtoReader.ParseFrom(ref ctx);
+            }
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("too many levels");
+    }
+
+    [Test]
+    public async Task SizeLimitExceeded_WhenSerializing()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            var bytes = SerializerTests.GetReadonlySequence(
+                new byte[] { 10, 8, 10, 4, 10, 2, 16, 1, 16, 1 }
+                    .Chunk(2)
+                    .ToArray()
+            );
+            var obj = Parse(bytes);
+            static TestContract Parse(ReadOnlySequence<byte> bytes)
+            {
+                ReaderContext.Initialize(bytes, out var ctx);
+                ctx.state.sizeLimit = 3;
+                return TestContract.ProtoReader.ParseFrom(ref ctx);
+            }
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("message was too large");
+    }
+
+    [ProtoContract]
+    public partial class MalformedVarint
+    {
+        [ProtoMember(1)]
+        public int Value { get; set; }
+    }
+
+    [Test]
+    public async Task MalformedVarint_WhenDeserializing()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+        {
+            var bytes = new byte[]
+            {
+                0x08,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+                0xFF,
+            };
+            var strings = Serializer.Deserialize<MalformedVarint>(bytes);
+            await Task.CompletedTask;
+        });
+        await Assert.That(ex!.Message).Contains("malformed varint");
+    }
+    // [Test]
+    // public async Task MoreDataAvailable_WhenDeserializing()
+    // {
+    //     var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
+    //     {
+    //         var bytes = new byte[] { 0x08, 0x96, 0x01, 0xFF, 0xFF};
+    //         var strings = Serializer.Deserialize<MalformedVarint>(
+    //             bytes
+    //         );
+    //         await Task.CompletedTask;
+    //     });
+    //     await Assert.That(ex!.Message).Contains("more data");
+    // }
+}

--- a/tests/LightProto.Tests/Parsers/ByteListTests.cs
+++ b/tests/LightProto.Tests/Parsers/ByteListTests.cs
@@ -1,0 +1,49 @@
+﻿using Google.Protobuf;
+using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ByteListTests
+    : BaseGoogleProtobufTests<ByteListTests.Message, ByteArrayTestsMessage>
+{
+    [ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        public List<byte> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property)}";
+        }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new()
+        {
+            Property = new() { 1, 2, 3, 4, 5 },
+        };
+        yield return new()
+        {
+            Property = new() { 0, 0, 0, 0, 0 },
+        };
+        yield return new() { Property = new() { 0 } };
+        yield return new() { Property = [] };
+    }
+
+    public override IEnumerable<ByteArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages()
+            .Select(o => new ByteArrayTestsMessage()
+            {
+                Property = ByteString.CopyFrom(o.Property.ToArray()),
+            });
+    }
+
+    public override async Task AssertGoogleResult(ByteArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToByteArray()).IsEquivalentTo(message.Property);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/FixedSizePackedArrayTests.cs
+++ b/tests/LightProto.Tests/Parsers/FixedSizePackedArrayTests.cs
@@ -1,0 +1,47 @@
+﻿using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class FixedSizePackedArrayTests
+    : BaseTests<FixedSizePackedArrayTests.Message, FixedSizeArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1, DataFormat = DataFormat.FixedSize, IsPacked = true)]
+        [ProtoBuf.ProtoMember(1, DataFormat = ProtoBuf.DataFormat.FixedSize, IsPacked = true)]
+        public int[] Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property)}";
+        }
+    }
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new int[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new int[] { -1, -2, -3, -4, -5 } };
+        yield return new() { Property = new int[] { 0, 0, 0, 0, 0 } };
+        //yield return new() { Property = new int[] { 0 } };
+        yield return new() { Property = [] };
+    }
+
+    public override IEnumerable<FixedSizeArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages()
+            .Select(o => new FixedSizeArrayTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(FixedSizeArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/parser.proto
+++ b/tests/LightProto.Tests/Parsers/parser.proto
@@ -58,6 +58,10 @@ message ListPackedTestsMessage
 {
   repeated int32 Property = 1;
 }
+message FixedSizeArrayTestsMessage
+{
+  repeated sfixed32 Property = 1;
+}
 message ListUnPackedTestsMessage
 {
   repeated int32 Property = 1 [packed = false];

--- a/tests/LightProto.Tests/SerializerTests.cs
+++ b/tests/LightProto.Tests/SerializerTests.cs
@@ -74,7 +74,7 @@ public partial class SerializerTests
         }
     }
 
-    ReadOnlySequence<byte> GetReadonlySequence(byte[][] bytesArray)
+    public static ReadOnlySequence<byte> GetReadonlySequence(byte[][] bytesArray)
     {
         var firstBufferSegment = new BufferSegment(bytesArray[0]);
         BufferSegment lastBufferSegment = firstBufferSegment;

--- a/tests/LightProto.Tests/generate_coverage.sh
+++ b/tests/LightProto.Tests/generate_coverage.sh
@@ -1,2 +1,2 @@
 ﻿#!/usr/bin/env bash
-dotnet run --coverage -f net9.0 --coverage-output-format cobertura --coverage-output ./coverage.cobertura.xml && reportgenerator.exe -reports:bin/Debug/net9.0/TestResults/coverage.cobertura.xml -targetdir:./coverage
+dotnet run -f net9.0 -c Release -p:PublishAot=false -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml && reportgenerator.exe -reports:bin/Release/net9.0/TestResults/coverage.cobertura.xml -targetdir:./coverage


### PR DESCRIPTION
Removed unused constructors, properties, and methods from CodedOutputStream, WriteBufferHelper, WriterContext, and related files to simplify the codebase. Added new test files for failed cases, byte list parsing, and fixed-size packed array parsing. Updated BaseTests to support Google.Protobuf interop tests. Modified project file to expose internals to test project. Updated coverage script for release builds.