### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
   
   windows-test:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/dameng324/LightProto/security/code-scanning/1](https://github.com/dameng324/LightProto/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the `windows-test` job in `.github/workflows/ci.yml`. This block should set the minimum required permissions. Since the job only appears to check out code and run tests/build steps, the minimal permission needed is likely `contents: read`. The `permissions` block should be inserted under the `windows-test:` key (the same level as `runs-on:`) before the `steps:` section. No additional imports or definitions are needed; this is a pure YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
