### PR TITLE
Skip readonly and const members in code generation

### DIFF
--- a/src/LightProto.Generator/LightProtoGenerator.cs
+++ b/src/LightProto.Generator/LightProtoGenerator.cs
@@ -1929,16 +1929,10 @@ public class LightProtoGenerator : IIncrementalGenerator
                     continue;
                 }
 
-                if (member is IFieldSymbol { IsReadOnly: true })
+                if (member is IFieldSymbol { IsReadOnly: true } or IFieldSymbol { IsConst: true })
                 {
                     continue;
                 }
-
-                if (member is IFieldSymbol { IsConst: true })
-                {
-                    continue;
-                }
-
                 if (
                     member
                         .GetAttributes()

--- a/src/LightProto.Generator/LightProtoGenerator.cs
+++ b/src/LightProto.Generator/LightProtoGenerator.cs
@@ -1924,6 +1924,21 @@ public class LightProtoGenerator : IIncrementalGenerator
                     continue;
                 }
 
+                if (member is IPropertySymbol { IsReadOnly: true })
+                {
+                    continue;
+                }
+
+                if (member is IFieldSymbol { IsReadOnly: true })
+                {
+                    continue;
+                }
+
+                if (member is IFieldSymbol { IsConst: true })
+                {
+                    continue;
+                }
+
                 if (
                     member
                         .GetAttributes()

--- a/tests/LightProto.Tests/Parsers/ImplicitFieldsAllPublicTests.cs
+++ b/tests/LightProto.Tests/Parsers/ImplicitFieldsAllPublicTests.cs
@@ -20,6 +20,8 @@ public partial class ImplicitFieldsAllPublicTests
         public int Property2;
         public int Property3 { get; set; }
         private int Property4 { get; set; }
+        public int Property5 => Property4;
+        public readonly int Property6 = 6;
 
         public int GetProperty4() => Property4;
 
@@ -65,8 +67,7 @@ public partial class ImplicitFieldsAllPublicTests
         public int Property2;
         public int Property3 { get; set; }
         private int Property4 { get; set; }
-
-        public int GetProperty4() => Property4;
+        public int Property5 => Property4;
 
         public static IEnumerable<ProtoBufMessage> GetMessages()
         {
@@ -122,11 +123,11 @@ public partial class ImplicitFieldsAllPublicTests
         await Assert.That(lightProto.Property3).IsEqualTo(protobuf.Property3);
         if (lightProtoToProtoBuf)
         {
-            await Assert.That(protobuf.GetProperty4()).IsEqualTo(0);
+            await Assert.That(protobuf.Property5).IsEqualTo(0);
         }
         else
         {
-            await Assert.That(lightProto.GetProperty4()).IsEqualTo(0);
+            await Assert.That(lightProto.Property5).IsEqualTo(0);
         }
     }
 }

--- a/tests/LightProto.Tests/Parsers/ImplicitFieldsAllPublicTests.cs
+++ b/tests/LightProto.Tests/Parsers/ImplicitFieldsAllPublicTests.cs
@@ -67,7 +67,8 @@ public partial class ImplicitFieldsAllPublicTests
         public int Property2;
         public int Property3 { get; set; }
         private int Property4 { get; set; }
-        public int Property5 => Property4;
+
+        public int GetProperty5() => Property4;
 
         public static IEnumerable<ProtoBufMessage> GetMessages()
         {
@@ -123,7 +124,7 @@ public partial class ImplicitFieldsAllPublicTests
         await Assert.That(lightProto.Property3).IsEqualTo(protobuf.Property3);
         if (lightProtoToProtoBuf)
         {
-            await Assert.That(protobuf.Property5).IsEqualTo(0);
+            await Assert.That(protobuf.GetProperty5()).IsEqualTo(0);
         }
         else
         {


### PR DESCRIPTION
Updated LightProtoGenerator to ignore readonly properties, readonly fields, and const fields during code generation. This prevents these members from being processed, ensuring only mutable members are considered.