### PR TITLE
Make collection serializer and deserializer methods public

### DIFF
--- a/src/LightProto/InvalidProtocolBufferException.cs
+++ b/src/LightProto/InvalidProtocolBufferException.cs
@@ -15,7 +15,7 @@ namespace LightProto
     /// </summary>
     public sealed class InvalidProtocolBufferException : IOException
     {
-        internal InvalidProtocolBufferException(string message)
+        public InvalidProtocolBufferException(string message)
             : base(message) { }
 
         internal InvalidProtocolBufferException(string message, Exception innerException)

--- a/src/LightProto/Serializer.Collection.Deserializer.cs
+++ b/src/LightProto/Serializer.Collection.Deserializer.cs
@@ -52,7 +52,7 @@ public static partial class Serializer
         where TCollection : ICollection<TItem>, new() =>
         Deserialize(source, GetCollectionMessageReader<TCollection, TItem>(reader));
 
-    internal static IEnumerableProtoReader<TCollection, TItem> GetCollectionReader<
+    public static IEnumerableProtoReader<TCollection, TItem> GetCollectionReader<
         TCollection,
         TItem
     >(this IProtoReader<TItem> reader)

--- a/src/LightProto/Serializer.Collection.Serializer.cs
+++ b/src/LightProto/Serializer.Collection.Serializer.cs
@@ -36,10 +36,10 @@ public static partial class Serializer
         ctx.Flush();
     }
 
-    internal static IProtoWriter<ICollection<T>> GetCollectionWriter<T>(this IProtoWriter<T> writer)
+    public static IProtoWriter<ICollection<T>> GetCollectionWriter<T>(this IProtoWriter<T> writer)
     {
-        uint tag = WireFormat.MakeTag(1, WireFormat.WireType.LengthDelimited);
-        uint tag2 = WireFormat.MakeTag(1, writer.WireType);
+        uint tag = WireFormat.MakeTag(1, writer.WireType);
+        uint tag2 = WireFormat.MakeTag(1, WireFormat.WireType.LengthDelimited);
         return new IEnumerableProtoWriter<ICollection<T>, T>(
             writer,
             tag,


### PR DESCRIPTION
Changed access modifiers from internal to public for GetCollectionReader and GetCollectionWriter methods to allow external usage. Also updated tag assignment logic in GetCollectionWriter for consistency.