### PR TITLE
Add IsRequired support to ProtoMemberAttribute

### DIFF
--- a/src/LightProto/Attributes.cs
+++ b/src/LightProto/Attributes.cs
@@ -34,8 +34,10 @@ public class ProtoMemberAttribute(uint tag) : Attribute
     public uint Tag { get; } = tag;
     public DataFormat DataFormat { get; set; } = DataFormat.Default;
 
-    // [Obsolete("compatibility protobuf-net only, no effect")]
-    // public bool IsRequired { get; set; } = false;
+    /// <summary>
+    /// If true, the member must be present when deserializing; if it is not, an exception will be thrown.
+    /// </summary>
+    public bool IsRequired { get; set; } = false;
     public bool IsPacked { get; set; } = false;
 
     // [Obsolete("compatibility protobuf-net only, no effect")]


### PR DESCRIPTION
This pull request introduces support for the `IsRequired` property on the `ProtoMemberAttribute`, ensuring that required proto members are handled correctly during serialization and deserialization. The changes update both attribute definitions and the code generation logic to enforce presence checks for required fields and to throw exceptions if required members are missing during deserialization.

Key changes include:

**Support for Required Proto Members:**

* Added the `IsRequired` property to the `ProtoMemberAttribute`, allowing proto members to be explicitly marked as required.
* Updated the code generation logic to recognize and propagate the `IsRequired` property as `IsProtoMemberRequired` in the generated code. [[1]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dR1906) [[2]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dR1932-R1939) [[3]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dR1985) [[4]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dR2170) [[5]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL2212-R2215)

**Serialization and Deserialization Logic:**

* Changed the generated code to always write required fields, bypassing empty/null checks for members marked as required.
* Updated deserialization logic to track presence of required fields and to throw exceptions if they are missing. The presence tracking now uses `IsProtoMemberRequired` instead of the previous null-check logic. [[1]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL741-R729) [[2]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL774-R762) [[3]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL783-R771) [[4]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL792-R780) [[5]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL804-R792)

**Code Cleanup and Consistency:**

* Refactored code to consistently use `IsProtoMemberRequired` for presence checks and exception handling, replacing the older `CheckNullWhenDeserializing` property.

**Bug Fixes:**

* Fixed the placement of closing braces in generated code to ensure correct scoping for collection and dictionary serialization. [[1]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL412-R428) [[2]](diffhunk://#diff-afd79e977f624666b73f67fbb36e2b52df34b87d770e30076bb0ca10b271ee5dL657-R667)

These changes ensure that proto members marked as required are properly enforced at runtime, improving data integrity and aligning behavior with expectations for required fields.