### PR TITLE
Performance Optimize Experiment

### DIFF
--- a/src/LightProto/CodedOutputStream.ComputeSize.cs
+++ b/src/LightProto/CodedOutputStream.ComputeSize.cs
@@ -221,7 +221,7 @@ namespace LightProto
         )]
         public static int ComputeLengthSize(int length)
         {
-            return ComputeRawVarint32Size((uint)length);
+            return 5;
         }
 
         /// <summary>

--- a/src/LightProto/IProtoParser.cs
+++ b/src/LightProto/IProtoParser.cs
@@ -19,6 +19,5 @@ public interface IProtoWriter<in T>
 {
     public WireFormat.WireType WireType { get; }
     public bool IsMessage { get; }
-    public int CalculateSize(T value);
     public void WriteTo(ref WriterContext output, T value);
 }

--- a/src/LightProto/InvalidProtocolBufferException.cs
+++ b/src/LightProto/InvalidProtocolBufferException.cs
@@ -83,5 +83,10 @@ namespace LightProto
                     + "Use CodedInputStream.SetSizeLimit() to increase the size limit."
             );
         }
+
+        internal static InvalidProtocolBufferException StringWriteFailed(string reason)
+        {
+            return new InvalidProtocolBufferException($"String write failed: {reason}");
+        }
     }
 }

--- a/src/LightProto/Parser/Bool.cs
+++ b/src/LightProto/Parser/Bool.cs
@@ -21,11 +21,6 @@ public sealed class BooleanProtoParser : IProtoParser<bool>
         public WireFormat.WireType WireType => WireFormat.WireType.Varint;
         public bool IsMessage => false;
 
-        public int CalculateSize(bool value)
-        {
-            return CodedOutputStream.ComputeBoolSize(value);
-        }
-
         public void WriteTo(ref WriterContext output, bool value)
         {
             output.WriteBool(value);

--- a/src/LightProto/Parser/ByteArray.cs
+++ b/src/LightProto/Parser/ByteArray.cs
@@ -22,18 +22,9 @@ public sealed class ByteArrayProtoParser : IProtoParser<byte[]>
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
 
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
-        public int CalculateSize(byte[] value)
-        {
-            return CodedOutputStream.ComputeLengthSize(value.Length) + value.Length;
-        }
-
         public void WriteTo(ref WriterContext output, byte[] value)
         {
-            output.WriteLength(value.Length);
-            WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, value);
+            output.WriteBytes(value);
         }
     }
 }

--- a/src/LightProto/Parser/ByteList.cs
+++ b/src/LightProto/Parser/ByteList.cs
@@ -24,20 +24,9 @@ public sealed class ByteListProtoParser : IProtoParser<List<byte>>
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
 
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
-        public int CalculateSize(List<byte> value)
-        {
-            return CodedOutputStream.ComputeLengthSize(value.Count) + value.Count;
-        }
-
         public void WriteTo(ref WriterContext output, List<byte> value)
         {
-            output.WriteLength(value.Count);
-            WritingPrimitives.WriteRawBytes(
-                ref output.buffer,
-                ref output.state,
+            output.WriteBytes(
 #if NET5_0_OR_GREATER
                 CollectionsMarshal.AsSpan(value)
 #else

--- a/src/LightProto/Parser/DateOnly.cs
+++ b/src/LightProto/Parser/DateOnly.cs
@@ -22,14 +22,6 @@ public sealed class DateOnlyProtoParser : IProtoParser<DateOnly>
         public WireFormat.WireType WireType => WireFormat.WireType.Varint;
         public bool IsMessage => false;
 
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
-        public int CalculateSize(DateOnly value)
-        {
-            return CodedOutputStream.ComputeInt32Size(value.DayNumber);
-        }
-
         public void WriteTo(ref WriterContext output, DateOnly value)
         {
             output.WriteInt32(value.DayNumber);

--- a/src/LightProto/Parser/Decimal300.cs
+++ b/src/LightProto/Parser/Decimal300.cs
@@ -25,11 +25,6 @@ public sealed class Decimal300ProtoParser : IProtoParser<Decimal>
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
 
-        public int CalculateSize(Decimal value)
-        {
-            return CodedOutputStream.ComputeStringSize(value.ToString("G"));
-        }
-
         public void WriteTo(ref WriterContext output, Decimal value)
         {
             output.WriteString(value.ToString("G"));

--- a/src/LightProto/Parser/Double.cs
+++ b/src/LightProto/Parser/Double.cs
@@ -29,14 +29,6 @@ public sealed class DoubleProtoParser : IProtoParser<Double>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(Double value)
-        {
-            return CodedOutputStream.ComputeDoubleSize(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, Double value)
         {
             output.WriteDouble(value);

--- a/src/LightProto/Parser/Enum.cs
+++ b/src/LightProto/Parser/Enum.cs
@@ -27,12 +27,6 @@ public sealed class EnumProtoParser<T> : IProtoParser<T>
         public bool IsMessage => false;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int CalculateSize(T value)
-        {
-            return CodedOutputStream.ComputeEnumSize(Unsafe.As<T, int>(ref value));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteTo(ref WriterContext output, T value)
         {
             output.WriteEnum(Unsafe.As<T, int>(ref value));

--- a/src/LightProto/Parser/FixedInt32.cs
+++ b/src/LightProto/Parser/FixedInt32.cs
@@ -27,14 +27,6 @@ public sealed class Fixed32ProtoParser : IProtoParser<UInt32>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(UInt32 value)
-        {
-            return CodedOutputStream.ComputeFixed32Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, UInt32 value)
         {
             output.WriteFixed32(value);

--- a/src/LightProto/Parser/FixedInt64.cs
+++ b/src/LightProto/Parser/FixedInt64.cs
@@ -27,14 +27,6 @@ public sealed class Fixed64ProtoParser : IProtoParser<UInt64>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(UInt64 value)
-        {
-            return CodedOutputStream.ComputeFixed64Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, UInt64 value)
         {
             output.WriteFixed64(value);

--- a/src/LightProto/Parser/Guid300.cs
+++ b/src/LightProto/Parser/Guid300.cs
@@ -24,11 +24,6 @@ public sealed class Guid300ProtoParser : IProtoParser<Guid>
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
 
-        public int CalculateSize(Guid value)
-        {
-            return CodedOutputStream.ComputeStringSize(value.ToString());
-        }
-
         public void WriteTo(ref WriterContext output, Guid value)
         {
             output.WriteString(value.ToString());

--- a/src/LightProto/Parser/Int32.cs
+++ b/src/LightProto/Parser/Int32.cs
@@ -27,14 +27,6 @@ public sealed class Int32ProtoParser : IProtoParser<int>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(int value)
-        {
-            return CodedOutputStream.ComputeInt32Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, int value)
         {
             output.WriteInt32(value);

--- a/src/LightProto/Parser/Int64.cs
+++ b/src/LightProto/Parser/Int64.cs
@@ -27,14 +27,6 @@ public sealed class Int64ProtoParser : IProtoParser<Int64>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(Int64 value)
-        {
-            return CodedOutputStream.ComputeInt64Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, Int64 value)
         {
             output.WriteInt64(value);

--- a/src/LightProto/Parser/KeyValuePair.cs
+++ b/src/LightProto/Parser/KeyValuePair.cs
@@ -92,32 +92,6 @@ public class KeyValuePairProtoWriter<TKey, TValue> : IProtoWriter<KeyValuePair<T
     public bool IsMessage => true;
     public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
 
-    public int CalculateSize(KeyValuePair<TKey, TValue> value)
-    {
-        int size = 0;
-        if (_keyWriter is ICollectionWriter)
-        {
-            size += _keyWriter.CalculateSize(value.Key);
-        }
-        else
-        {
-            size += CodedOutputStream.ComputeRawVarint32Size(_keyTag);
-            size += _keyWriter.CalculateMessageSize(value.Key);
-        }
-
-        if (_valueWriter is ICollectionWriter)
-        {
-            size += _valueWriter.CalculateSize(value.Value);
-        }
-        else
-        {
-            size += CodedOutputStream.ComputeRawVarint32Size(_valueTag);
-            size += _valueWriter.CalculateMessageSize(value.Value);
-        }
-
-        return size;
-    }
-
     public void WriteTo(ref WriterContext output, KeyValuePair<TKey, TValue> pair)
     {
         if (_keyWriter is ICollectionWriter)

--- a/src/LightProto/Parser/MessageWrapper.cs
+++ b/src/LightProto/Parser/MessageWrapper.cs
@@ -30,17 +30,6 @@ struct MessageWrapper<T>
 
             ItemWriter.WriteTo(ref output, value);
         }
-
-        public int CalculateSize(T value)
-        {
-            int size = 0;
-            if (ItemWriter is not ICollectionWriter)
-            {
-                size += CodedOutputStream.ComputeRawVarint32Size(tag);
-            }
-            size += ItemWriter.CalculateSize(value);
-            return size;
-        }
     }
 
     public struct ProtoReader : IProtoReader<T>

--- a/src/LightProto/Parser/Nullable.cs
+++ b/src/LightProto/Parser/Nullable.cs
@@ -36,14 +36,6 @@ public sealed class NullableProtoWriter<T> : IProtoWriter<Nullable<T>>
     [System.Runtime.CompilerServices.MethodImpl(
         System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
     )]
-    public int CalculateSize(Nullable<T> value)
-    {
-        return value.HasValue == false ? 0 : ValueWriter.CalculateMessageSize(value.Value);
-    }
-
-    [System.Runtime.CompilerServices.MethodImpl(
-        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-    )]
     public void WriteTo(ref WriterContext output, Nullable<T> value)
     {
         if (value.HasValue)

--- a/src/LightProto/Parser/SFixed32.cs
+++ b/src/LightProto/Parser/SFixed32.cs
@@ -27,14 +27,6 @@ public sealed class SFixed32ProtoParser : IProtoParser<int>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(int value)
-        {
-            return CodedOutputStream.ComputeSFixed32Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, int value)
         {
             output.WriteSFixed32(value);

--- a/src/LightProto/Parser/SFixed64.cs
+++ b/src/LightProto/Parser/SFixed64.cs
@@ -27,14 +27,6 @@ public sealed class SFixed64ProtoParser : IProtoParser<Int64>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(Int64 value)
-        {
-            return CodedOutputStream.ComputeSFixed64Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, Int64 value)
         {
             output.WriteSFixed64(value);

--- a/src/LightProto/Parser/SInt32.cs
+++ b/src/LightProto/Parser/SInt32.cs
@@ -27,14 +27,6 @@ public sealed class SInt32ProtoParser : IProtoParser<Int32>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(Int32 value)
-        {
-            return CodedOutputStream.ComputeSInt32Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, Int32 value)
         {
             output.WriteSInt32(value);

--- a/src/LightProto/Parser/SInt64.cs
+++ b/src/LightProto/Parser/SInt64.cs
@@ -27,14 +27,6 @@ public sealed class SInt64ProtoParser : IProtoParser<Int64>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(Int64 value)
-        {
-            return CodedOutputStream.ComputeSInt64Size(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, Int64 value)
         {
             output.WriteSInt64(value);

--- a/src/LightProto/Parser/Single.cs
+++ b/src/LightProto/Parser/Single.cs
@@ -27,14 +27,6 @@ public sealed class SingleProtoParser : IProtoParser<Single>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(Single value)
-        {
-            return CodedOutputStream.ComputeFloatSize(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, Single value)
         {
             output.WriteFloat(value);

--- a/src/LightProto/Parser/String.cs
+++ b/src/LightProto/Parser/String.cs
@@ -27,14 +27,6 @@ public sealed class StringProtoParser : IProtoParser<string>
         [System.Runtime.CompilerServices.MethodImpl(
             System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
         )]
-        public int CalculateSize(string value)
-        {
-            return CodedOutputStream.ComputeStringSize(value);
-        }
-
-        [System.Runtime.CompilerServices.MethodImpl(
-            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining
-        )]
         public void WriteTo(ref WriterContext output, string value)
         {
             output.WriteString(value);

--- a/src/LightProto/Parser/StringBuilder.cs
+++ b/src/LightProto/Parser/StringBuilder.cs
@@ -23,24 +23,6 @@ public sealed class StringBuilderProtoParser : IProtoParser<StringBuilder>
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
 
-        public int CalculateSize(StringBuilder value)
-        {
-#if NET5_0_OR_GREATER
-            int size = 0;
-            foreach (var readOnlyMemory in value.GetChunks())
-            {
-                int byteArraySize = WritingPrimitives.Utf8Encoding.GetByteCount(
-                    readOnlyMemory.Span
-                );
-                size += CodedOutputStream.ComputeLengthSize(byteArraySize) + byteArraySize;
-            }
-            return size;
-#else
-            int byteArraySize = WritingPrimitives.Utf8Encoding.GetByteCount(value.ToString());
-            return CodedOutputStream.ComputeLengthSize(byteArraySize) + byteArraySize;
-#endif
-        }
-
         public void WriteTo(ref WriterContext output, StringBuilder value)
         {
             output.WriteString(value.ToString());

--- a/src/LightProto/Parser/TimeOnly.cs
+++ b/src/LightProto/Parser/TimeOnly.cs
@@ -22,11 +22,6 @@ public sealed class TimeOnlyProtoParser : IProtoParser<TimeOnly>
         public WireFormat.WireType WireType => WireFormat.WireType.Varint;
         public bool IsMessage => false;
 
-        public int CalculateSize(TimeOnly value)
-        {
-            return CodedOutputStream.ComputeInt64Size(value.Ticks);
-        }
-
         public void WriteTo(ref WriterContext output, TimeOnly value)
         {
             output.WriteInt64(value.Ticks);

--- a/src/LightProto/Parser/UInt32.cs
+++ b/src/LightProto/Parser/UInt32.cs
@@ -21,11 +21,6 @@ public sealed class UInt32ProtoParser : IProtoParser<UInt32>
         public WireFormat.WireType WireType => WireFormat.WireType.Varint;
         public bool IsMessage => false;
 
-        public int CalculateSize(UInt32 value)
-        {
-            return CodedOutputStream.ComputeUInt32Size(value);
-        }
-
         public void WriteTo(ref WriterContext output, UInt32 value)
         {
             output.WriteUInt32(value);

--- a/src/LightProto/Parser/UInt64.cs
+++ b/src/LightProto/Parser/UInt64.cs
@@ -21,11 +21,6 @@ public sealed class UInt64ProtoParser : IProtoParser<UInt64>
         public WireFormat.WireType WireType => WireFormat.WireType.Varint;
         public bool IsMessage => false;
 
-        public int CalculateSize(UInt64 value)
-        {
-            return CodedOutputStream.ComputeUInt64Size(value);
-        }
-
         public void WriteTo(ref WriterContext output, UInt64 value)
         {
             output.WriteUInt64(value);

--- a/src/LightProto/WriterContext.cs
+++ b/src/LightProto/WriterContext.cs
@@ -8,8 +8,11 @@
 #endregion
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security;
+using System.Text;
 
 namespace LightProto
 {
@@ -22,149 +25,250 @@ namespace LightProto
     [SecuritySafeCritical]
     public ref struct WriterContext
     {
-        internal Span<byte> buffer;
-        internal WriterInternalState state;
+        private readonly IBufferWriter<byte> _bufferWriter;
+        public int WrittenCount { get; set; }
 
-        /// <summary>
-        /// Creates a WriteContext instance from CodedOutputStream.
-        /// WARNING: internally this copies the CodedOutputStream's state, so after done with the WriteContext,
-        /// the CodedOutputStream's state needs to be updated.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Initialize(CodedOutputStream output, out WriterContext ctx)
+        public WriterContext(IBufferWriter<byte> bufferWriter)
         {
-            ctx.buffer = new Span<byte>(output.InternalBuffer);
-            // ideally we would use a reference to the original state, but that doesn't seem possible
-            // so we just copy the struct that holds the state. We will need to later store the state back
-            // into CodedOutputStream if we want to keep it usable.
-            ctx.state = output.InternalState;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Initialize(IBufferWriter<byte> output, out WriterContext ctx)
-        {
-            ctx.buffer = default;
-            ctx.state = default;
-            WriteBufferHelper.Initialize(output, out ctx.state.writeBufferHelper, out ctx.buffer);
-            ctx.state.limit = ctx.buffer.Length;
-            ctx.state.position = 0;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Initialize(ref Span<byte> buffer, out WriterContext ctx)
-        {
-            ctx.buffer = buffer;
-            ctx.state = default;
-            ctx.state.limit = ctx.buffer.Length;
-            ctx.state.position = 0;
-            WriteBufferHelper.InitializeNonRefreshable(out ctx.state.writeBufferHelper);
+            _bufferWriter = bufferWriter;
+            WrittenCount = 0;
         }
 
         /// <summary>
         /// Writes a double field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteDouble(double value) =>
-            WritingPrimitives.WriteDouble(ref buffer, ref state, value);
+        public void WriteDouble(double value)
+        {
+            var span = _bufferWriter.GetSpan(8);
+            BinaryPrimitives.WriteUInt64LittleEndian(
+                span,
+                (ulong)BitConverter.DoubleToInt64Bits(value)
+            );
+            Advance(8);
+        }
+
+        void Advance(int count)
+        {
+            _bufferWriter.Advance(count);
+            WrittenCount += count;
+
+            if (_bufferWriter is ByteArrayPoolBufferWriter writer)
+            {
+                if (writer.WrittenCount != WrittenCount)
+                {
+                    throw new InvalidOperationException();
+                }
+            }
+        }
 
         /// <summary>
         /// Writes a float field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteFloat(float value) =>
-            WritingPrimitives.WriteFloat(ref buffer, ref state, value);
+        public void WriteFloat(float value)
+        {
+            var span = _bufferWriter.GetSpan(4);
+            Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(span), value);
+            Advance(4);
+        }
 
         /// <summary>
         /// Writes a uint64 field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteUInt64(ulong value) =>
-            WritingPrimitives.WriteUInt64(ref buffer, ref state, value);
+        public void WriteUInt64(ulong value) => WriteRawVarint64(value);
+
+        private void WriteRawVarint64(ulong value)
+        {
+            // Optimize for the common case of a single byte value
+            if (value < 128)
+            {
+                var span = _bufferWriter.GetSpan(1);
+                span[0] = (byte)value;
+                Advance(1);
+                return;
+            }
+
+            // Fast path when capacity is available
+            while (true)
+            {
+                if (value > 127)
+                {
+                    var span = _bufferWriter.GetSpan(1);
+                    span[0] = (byte)((value & 0x7F) | 0x80);
+                    Advance(1);
+                    value >>= 7;
+                }
+                else
+                {
+                    var span = _bufferWriter.GetSpan(1);
+                    span[0] = (byte)value;
+                    Advance(1);
+                    return;
+                }
+            }
+        }
 
         /// <summary>
         /// Writes an int64 field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteInt64(long value) =>
-            WritingPrimitives.WriteInt64(ref buffer, ref state, value);
+        public void WriteInt64(long value) => WriteRawVarint64((ulong)value);
 
         /// <summary>
         /// Writes an int32 field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteInt32(int value) =>
-            WritingPrimitives.WriteInt32(ref buffer, ref state, value);
+        public void WriteInt32(int value)
+        {
+            WriteRawVarint64((ulong)value);
+        }
 
         /// <summary>
         /// Writes a fixed64 field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteFixed64(ulong value) =>
-            WritingPrimitives.WriteFixed64(ref buffer, ref state, value);
+        public void WriteFixed64(ulong value)
+        {
+            const int length = sizeof(ulong);
+            var span = _bufferWriter.GetSpan(length);
+            BinaryPrimitives.WriteUInt64LittleEndian(span, value);
+            Advance(length);
+        }
 
         /// <summary>
         /// Writes a fixed32 field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteFixed32(uint value) =>
-            WritingPrimitives.WriteFixed32(ref buffer, ref state, value);
+        public void WriteFixed32(uint value)
+        {
+            const int length = sizeof(uint);
+            var span = _bufferWriter.GetSpan(length);
+            BinaryPrimitives.WriteUInt32LittleEndian(span, value);
+            Advance(length);
+        }
 
         /// <summary>
         /// Writes a bool field value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteBool(bool value) =>
-            WritingPrimitives.WriteBool(ref buffer, ref state, value);
+        public void WriteBool(bool value)
+        {
+            var span = _bufferWriter.GetSpan(1);
+            span[0] = (byte)(value ? 1 : 0);
+            Advance(1);
+        }
 
         /// <summary>
         /// Writes a string field value, without a tag.
         /// The data is length-prefixed.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteString(string value) =>
-            WritingPrimitives.WriteString(ref buffer, ref state, value);
+        public void WriteString(string value)
+        {
+            var lengthSpan = _bufferWriter.GetSpan(5);
+            Advance(5);
+
+            var maxByteCount = (value.Length + 1) * 3;
+            var dest = _bufferWriter.GetSpan(maxByteCount);
+#if NET7_0_OR_GREATER
+            var status = System.Text.Unicode.Utf8.FromUtf16(
+                value,
+                dest,
+                out var _,
+                out var bytesWritten,
+                replaceInvalidSequences: false
+            );
+            if (status != OperationStatus.Done)
+            {
+                throw InvalidProtocolBufferException.StringWriteFailed(status.ToString());
+            }
+#else
+            int bytesWritten;
+            unsafe
+            {
+                fixed (char* sourceChars = &MemoryMarshal.GetReference(value.AsSpan()))
+                fixed (byte* destinationBytes = &MemoryMarshal.GetReference(dest))
+                {
+                    bytesWritten = Encoding.UTF8.GetBytes(
+                        sourceChars,
+                        value.Length,
+                        destinationBytes,
+                        maxByteCount
+                    );
+                }
+            }
+#endif
+            WriteLength(lengthSpan, bytesWritten);
+            Advance(bytesWritten);
+        }
+
+        public void WriteBytes(Span<byte> bytes)
+        {
+            var lengthSpan = _bufferWriter.GetSpan(5);
+            WriteLength(lengthSpan, bytes.Length);
+            Advance(5);
+            var span = _bufferWriter.GetSpan(bytes.Length);
+            bytes.CopyTo(span);
+            Advance(bytes.Length);
+        }
 
         /// <summary>
         /// Writes a uint32 value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteUInt32(uint value) =>
-            WritingPrimitives.WriteUInt32(ref buffer, ref state, value);
+        public void WriteUInt32(uint value)
+        {
+            WriteRawVarint64(value);
+        }
 
         /// <summary>
         /// Writes an enum value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteEnum(int value) =>
-            WritingPrimitives.WriteEnum(ref buffer, ref state, value);
+        public void WriteEnum(int value) => WriteRawVarint64((ulong)value);
 
         /// <summary>
         /// Writes an sfixed32 value, without a tag.
         /// </summary>
         /// <param name="value">The value to write.</param>
-        public void WriteSFixed32(int value) =>
-            WritingPrimitives.WriteSFixed32(ref buffer, ref state, value);
+        public void WriteSFixed32(int value)
+        {
+            WriteFixed32((uint)value);
+        }
 
         /// <summary>
         /// Writes an sfixed64 value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteSFixed64(long value) =>
-            WritingPrimitives.WriteSFixed64(ref buffer, ref state, value);
+        public void WriteSFixed64(long value) => WriteFixed64((ulong)value);
 
         /// <summary>
         /// Writes an sint32 value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteSInt32(int value) =>
-            WritingPrimitives.WriteSInt32(ref buffer, ref state, value);
+        public void WriteSInt32(int value)
+        {
+            WriteRawVarint64(EncodeZigZag32(value));
+        }
+
+        static uint EncodeZigZag32(int n)
+        {
+            // Note:  the right-shift must be arithmetic
+            return (uint)((n << 1) ^ (n >> 31));
+        }
+
+        public static ulong EncodeZigZag64(long n)
+        {
+            return (ulong)((n << 1) ^ (n >> 63));
+        }
 
         /// <summary>
         /// Writes an sint64 value, without a tag.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void WriteSInt64(long value) =>
-            WritingPrimitives.WriteSInt64(ref buffer, ref state, value);
+        public void WriteSInt64(long value) => WriteRawVarint64(EncodeZigZag64(value));
 
         /// <summary>
         /// Writes a length (in bytes) for length-delimited data.
@@ -173,15 +277,30 @@ namespace LightProto
         /// This method simply writes a rawint, but exists for clarity in calling code.
         /// </remarks>
         /// <param name="length">Length value, in bytes.</param>
-        public void WriteLength(int length) =>
-            WritingPrimitives.WriteLength(ref buffer, ref state, length);
+        public void WriteLength(Span<byte> span, int value)
+        {
+            span[0] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+            span[1] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+            span[2] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+            span[3] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+            span[4] = (byte)((value & 0x7F) | 0x00);
+        }
 
         /// <summary>
         /// Writes an already-encoded tag.
         /// </summary>
         /// <param name="tag">The encoded tag</param>
-        public void WriteTag(uint tag) => WritingPrimitives.WriteTag(ref buffer, ref state, tag);
+        public void WriteTag(uint tag) => WriteRawVarint64(tag);
 
-        internal void Flush() => WriteBufferHelper.Flush(ref buffer, ref state);
+        internal Span<byte> GetLengthSpan()
+        {
+            var span = _bufferWriter.GetSpan(5);
+            Advance(5);
+            return span;
+        }
     }
 }

--- a/tests/LightProto.Tests/CustomParser/CustomPriorityTests.cs
+++ b/tests/LightProto.Tests/CustomParser/CustomPriorityTests.cs
@@ -35,11 +35,6 @@ public partial class CustomPriorityTests
             public WireFormat.WireType WireType { get; } = WireFormat.WireType.Varint;
             public bool IsMessage { get; } = false;
 
-            public int CalculateSize(Person value)
-            {
-                return CodedOutputStream.ComputeInt32Size(value.Id);
-            }
-
             public void WriteTo(ref WriterContext output, Person value)
             {
                 output.WriteInt32(value.Id);

--- a/tests/LightProto.Tests/CustomParser/StructCustomPriorityTests.cs
+++ b/tests/LightProto.Tests/CustomParser/StructCustomPriorityTests.cs
@@ -33,11 +33,6 @@ public partial class StructCustomPriorityTests
             public WireFormat.WireType WireType { get; } = WireFormat.WireType.Varint;
             public bool IsMessage { get; } = false;
 
-            public int CalculateSize(Person value)
-            {
-                return CodedOutputStream.ComputeInt32Size(value.Id);
-            }
-
             public void WriteTo(ref WriterContext output, Person value)
             {
                 output.WriteInt32(value.Id);

--- a/tests/LightProto.Tests/FailedTests.cs
+++ b/tests/LightProto.Tests/FailedTests.cs
@@ -366,20 +366,20 @@ public partial class FailedTests
         await Assert.That(parsed).IsEquivalentTo(original);
     }
 
-    [Test]
-    public async Task OutOfSpaceExceptionTest()
-    {
-        var ex = Assert.Throws<CodedOutputStream.OutOfSpaceException>(() =>
-        {
-            var message = "1234567";
-            var writer = StringProtoParser.ProtoWriter;
-            var buffer = new byte[writer.CalculateSize(message) - 1];
-            using CodedOutputStream output = new CodedOutputStream(buffer);
-            WriterContext.Initialize(output, out var ctx);
-            writer.WriteTo(ref ctx, message);
-            ctx.Flush();
-        });
-        await Assert.That(ex!.Message).Contains("ran out of space");
-    }
+    // [Test]
+    // public async Task OutOfSpaceExceptionTest()
+    // {
+    //     var ex = Assert.Throws<CodedOutputStream.OutOfSpaceException>(() =>
+    //     {
+    //         var message = "1234567";
+    //         var writer = StringProtoParser.ProtoWriter;
+    //         var buffer = new byte[writer.CalculateSize(message) - 1];
+    //         using CodedOutputStream output = new CodedOutputStream(buffer);
+    //         WriterContext.Initialize(output, out var ctx);
+    //         writer.WriteTo(ref ctx, message);
+    //         ctx.Flush();
+    //     });
+    //     await Assert.That(ex!.Message).Contains("ran out of space");
+    // }
 }
 #endif

--- a/tests/LightProto.Tests/IntergrationTests.cs
+++ b/tests/LightProto.Tests/IntergrationTests.cs
@@ -183,40 +183,22 @@ public class IntergrationTests
 
         var originalBytes = Convert.ToBase64String(origin.ToByteArray(ProtoParser<T1>.ProtoWriter));
         var t2Array = t2ToByteArray(parsed);
-        var parsedBytes = Convert.ToBase64String(t2Array);
-        try
-        {
-            await Assert.That(originalBytes).IsEqualTo(parsedBytes);
-            await Assert.That(t2Array.Length).IsEqualTo(
-#if NET6_0_OR_GREATER
-                Serializer.CalculateSize(origin)
-#else
-                    ProtoParser<T1>.ProtoWriter.CalculateSize(origin)
-#endif
-            );
-        }
-        catch (Exception)
-        {
-            Console.WriteLine($"original: {JsonSerializer.Serialize(origin)}");
-            Console.WriteLine($"parsed: {JsonSerializer.Serialize(parsed)}");
-            throw;
-        }
 
         var parseBack = LightProto.Serializer.Deserialize<T1>(bytes, ProtoParser<T1>.ProtoReader);
         var bytes2 = parseBack.ToByteArray(ProtoParser<T1>.ProtoWriter);
 
         var parseBackBytes = Convert.ToBase64String(bytes2);
         await Assert.That(parseBackBytes).IsEqualTo(originalBytes);
-#if NET6_0_OR_GREATER
-        await Assert
-            .That(Serializer.CalculateSize(parseBack))
-            .IsEqualTo(Serializer.CalculateSize(origin));
-#else
-        await Assert
-            .That(ProtoParser<T1>.ProtoWriter.CalculateSize(parseBack))
-            .IsEqualTo(ProtoParser<T1>.ProtoWriter.CalculateSize(origin));
-
-#endif
+        // #if NET6_0_OR_GREATER
+        //         await Assert
+        //             .That(Serializer.CalculateSize(parseBack))
+        //             .IsEqualTo(Serializer.CalculateSize(origin));
+        // #else
+        //         await Assert
+        //             .That(ProtoParser<T1>.ProtoWriter.CalculateSize(parseBack))
+        //             .IsEqualTo(ProtoParser<T1>.ProtoWriter.CalculateSize(origin));
+        //
+        // #endif
         return parsed;
     }
 

--- a/tests/LightProto.Tests/LightProto.Tests.csproj
+++ b/tests/LightProto.Tests/LightProto.Tests.csproj
@@ -14,6 +14,9 @@
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>$(TargetFrameworks);net48</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'Configuration' == 'Debug'">
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.30.2" />
     <!-- above 3.31 cause aot issue see: https://github.com/protocolbuffers/protobuf/issues/21824 -->

--- a/tests/LightProto.Tests/WriterContext.cs
+++ b/tests/LightProto.Tests/WriterContext.cs
@@ -1,0 +1,11 @@
+﻿namespace LightProto.Tests;
+
+public class WriterContextTest
+{
+    [Test]
+    public void WriteLengthTest()
+    {
+        ByteArrayPoolBufferWriter writer = new ByteArrayPoolBufferWriter();
+        var ctx = new LightProto.WriterContext(writer);
+    }
+}


### PR DESCRIPTION
# Motivation

In Protobuf, when serializing a message, a MessageLength (encoded as a Varint) must be written before the message body.
This requires two serialization passes — one to compute the MessageLength, and another to actually write the message.

Although the size calculation step has been highly optimized, it can still incur noticeable overhead when messages are deeply nested.

This PR aims to explore the possibility of performing serialization in a single pass — that is, writing the message only once, while determining its length during the write process, and then backfilling the MessageLength field afterward.

---
## Current Progress

The first challenge encountered was that Varint is a variable-length format, so we cannot know in advance how many bytes to reserve for the message length.

This issue was solved in a somewhat hacky but effective way:
by always reserving 5 bytes for the Varint and encoding it in a way that remains compatible with both protobuf-net and Google.Protobuf decoders.

Although this encoding is technically non-standard, it is still valid according to the Protobuf Varint decoding rules.

```cs
public void WriteLength(Span<byte> span, int value)
{
    span[0] = (byte)((value & 0x7F) | 0x80);
    value >>= 7;
    span[1] = (byte)((value & 0x7F) | 0x80);
    value >>= 7;
    span[2] = (byte)((value & 0x7F) | 0x80);
    value >>= 7;
    span[3] = (byte)((value & 0x7F) | 0x80);
    value >>= 7;
    span[4] = (byte)((value & 0x7F) | 0x00);
}
```
So far, everything worked quite well — until the next issue arose.

---
## The Main Challenge

The IBufferWriter interface only provides GetSpan/GetMemory and Advance methods.
When we reserve space for the message length using GetSpan, this memory is no longer guaranteed to be valid once Advance is called.

Due to the buffer writer’s internal growth mechanism, the reserved span for MessageLength might become invalid when writing the message body — meaning the memory could have been reallocated or replaced.
By the time we want to backfill the length, the original span may refer to outdated memory, and there’s no reliable way to access the new span corresponding to that same position.

---
## Solutions Considered

Use a custom IBufferWriter implementation.
Not feasible, since this serializer aims to work with any user-provided IBufferWriter.

Use unsafe code to access the pointer of the message body and move backward to the length prefix region.
Unsafe and unreliable — there’s no guarantee that the length prefix and message body reside in contiguous memory.

Write the message body into a temporary buffer first, compute its length, then write both length and body to the user’s writer.
This works functionally but introduces extra allocations and copying, which can be expensive for large or deeply nested messages — essentially defeating the purpose of this optimization.

---
## Request for Feedback

At this point, the PR is paused here.
If anyone has better ideas or knows of an elegant way to solve this problem while maintaining compatibility with the IBufferWriter interface, I would love to hear your thoughts.

Thank you for reading and for any suggestions or insights you might share.