### PR TITLE
Add  ImmutableArray, ImmutableList, ImmutableHashSet, and ImmutableDictionary Support

### DIFF
--- a/src/LightProto/LightProto.csproj
+++ b/src/LightProto/LightProto.csproj
@@ -41,5 +41,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/LightProto/Parser/ImmutableArray.cs
+++ b/src/LightProto/Parser/ImmutableArray.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Immutable;
+
+namespace LightProto.Parser;
+
+public sealed class ImmutableArrayProtoWriter<T> : IEnumerableProtoWriter<ImmutableArray<T>, T>
+{
+    public ImmutableArrayProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
+        : base(itemWriter, tag, static collection => collection.Length, itemFixedSize) { }
+}
+
+public sealed class ImmutableArrayProtoReader<TItem>
+    : ICollectionReader<ImmutableArray<TItem>, TItem>
+{
+    private readonly ArrayProtoReader<TItem> _arrayReader;
+    public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+    public bool IsMessage => false;
+
+    public ImmutableArray<TItem> ParseFrom(ref ReaderContext input)
+    {
+        return ImmutableArray.Create(_arrayReader.ParseFrom(ref input));
+    }
+
+    public WireFormat.WireType ItemWireType => ItemReader.WireType;
+    public IProtoReader<TItem> ItemReader { get; }
+    public int ItemFixedSize { get; }
+
+    public ImmutableArrayProtoReader(IProtoReader<TItem> itemReader, int itemFixedSize)
+    {
+        _arrayReader = new ArrayProtoReader<TItem>(itemReader, itemFixedSize);
+        ItemReader = itemReader;
+        ItemFixedSize = itemFixedSize;
+    }
+
+    public ImmutableArrayProtoReader(IProtoReader<TItem> itemReader, uint tag, int itemFixedSize)
+        : this(itemReader, itemFixedSize) { }
+
+    public ImmutableArray<TItem> Empty => ImmutableArray<TItem>.Empty;
+}

--- a/src/LightProto/Parser/ImmutableDictionary.cs
+++ b/src/LightProto/Parser/ImmutableDictionary.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+
+namespace LightProto.Parser;
+
+public sealed class ImmutableDictionaryProtoWriter<TKey, TValue>
+    : IEnumerableKeyValuePairProtoWriter<ImmutableDictionary<TKey, TValue>, TKey, TValue>
+    where TKey : notnull
+{
+    public ImmutableDictionaryProtoWriter(
+        IProtoWriter<TKey> keyWriter,
+        IProtoWriter<TValue> valueWriter,
+        uint tag
+    )
+        : base(keyWriter, valueWriter, tag, (dic) => dic.Count) { }
+}
+
+public sealed class ImmutableDictionaryProtoReader<TKey, TValue>
+    : ICollectionReader<ImmutableDictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+{
+    private readonly DictionaryProtoReader<TKey, TValue> _dictionaryReader;
+    public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+    public bool IsMessage => false;
+
+    ImmutableDictionary<TKey, TValue> IProtoReader<ImmutableDictionary<TKey, TValue>>.ParseFrom(
+        ref ReaderContext input
+    ) => _dictionaryReader.ParseFrom(ref input).ToImmutableDictionary();
+
+    public WireFormat.WireType ItemWireType => ItemReader.WireType;
+
+    public ImmutableDictionaryProtoReader(
+        IProtoReader<TKey> keyReader,
+        IProtoReader<TValue> valueReader,
+        uint tag
+    )
+    {
+        _dictionaryReader = new DictionaryProtoReader<TKey, TValue>(keyReader, valueReader, tag);
+    }
+
+    public ImmutableDictionary<TKey, TValue> Empty => ImmutableDictionary<TKey, TValue>.Empty;
+    public IProtoReader<KeyValuePair<TKey, TValue>> ItemReader => _dictionaryReader.ItemReader;
+}

--- a/src/LightProto/Parser/ImmutableHashSet.cs
+++ b/src/LightProto/Parser/ImmutableHashSet.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Immutable;
+
+namespace LightProto.Parser;
+
+public sealed class ImmutableHashSetProtoWriter<T> : IEnumerableProtoWriter<ImmutableHashSet<T>, T>
+{
+    public ImmutableHashSetProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
+        : base(itemWriter, tag, static collection => collection.Count, itemFixedSize) { }
+}
+
+public sealed class ImmutableHashSetProtoReader<TItem>
+    : ICollectionReader<ImmutableHashSet<TItem>, TItem>
+{
+    private readonly ArrayProtoReader<TItem> _arrayReader;
+    public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+    public bool IsMessage => false;
+
+    public ImmutableHashSet<TItem> ParseFrom(ref ReaderContext input)
+    {
+        return ImmutableHashSet.Create(_arrayReader.ParseFrom(ref input));
+    }
+
+    public WireFormat.WireType ItemWireType => ItemReader.WireType;
+    public IProtoReader<TItem> ItemReader { get; }
+    public int ItemFixedSize { get; }
+
+    public ImmutableHashSetProtoReader(IProtoReader<TItem> itemReader, int itemFixedSize)
+    {
+        _arrayReader = new ArrayProtoReader<TItem>(itemReader, itemFixedSize);
+        ItemReader = itemReader;
+        ItemFixedSize = itemFixedSize;
+    }
+
+    public ImmutableHashSetProtoReader(IProtoReader<TItem> itemReader, uint tag, int itemFixedSize)
+        : this(itemReader, itemFixedSize) { }
+
+    public ImmutableHashSet<TItem> Empty => ImmutableHashSet<TItem>.Empty;
+}

--- a/src/LightProto/Parser/ImmutableList.cs
+++ b/src/LightProto/Parser/ImmutableList.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Immutable;
+
+namespace LightProto.Parser;
+
+public sealed class ImmutableListProtoWriter<T> : IEnumerableProtoWriter<ImmutableList<T>, T>
+{
+    public ImmutableListProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
+        : base(itemWriter, tag, static collection => collection.Count, itemFixedSize) { }
+}
+
+public sealed class ImmutableListProtoReader<TItem> : ICollectionReader<ImmutableList<TItem>, TItem>
+{
+    private readonly ArrayProtoReader<TItem> _arrayReader;
+    public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+    public bool IsMessage => false;
+
+    public ImmutableList<TItem> ParseFrom(ref ReaderContext input)
+    {
+        return ImmutableList.Create(_arrayReader.ParseFrom(ref input));
+    }
+
+    public WireFormat.WireType ItemWireType => ItemReader.WireType;
+    public IProtoReader<TItem> ItemReader { get; }
+    public int ItemFixedSize { get; }
+
+    public ImmutableListProtoReader(IProtoReader<TItem> itemReader, int itemFixedSize)
+    {
+        _arrayReader = new ArrayProtoReader<TItem>(itemReader, itemFixedSize);
+        ItemReader = itemReader;
+        ItemFixedSize = itemFixedSize;
+    }
+
+    public ImmutableListProtoReader(IProtoReader<TItem> itemReader, uint tag, int itemFixedSize)
+        : this(itemReader, itemFixedSize) { }
+
+    public ImmutableList<TItem> Empty => ImmutableList<TItem>.Empty;
+}

--- a/tests/LightProto.Tests/Parsers/ImmutableArrayTests.cs
+++ b/tests/LightProto.Tests/Parsers/ImmutableArrayTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ImmutableArrayTests : BaseTests<ImmutableArrayTests.Message, ArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ImmutableArray<int> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property)}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = [1, 2, 3, 4, 5] };
+        yield return new() { Property = [-1, -2, -3, -4, -5] };
+        yield return new() { Property = [0, 0, 0, 0, 0] };
+        yield return new() { Property = [0] };
+        yield return new() { Property = [] };
+    }
+
+    public override IEnumerable<ArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ArrayTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(ArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(
+            bytes,
+            new ImmutableArrayProtoReader<int>(Int32ProtoParser.ProtoReader, 0)
+        );
+        await Assert.That(deserialized.IsDefaultOrEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ImmutableDictionary.cs
+++ b/tests/LightProto.Tests/Parsers/ImmutableDictionary.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ImmutableDictionaryTests
+    : BaseTests<ImmutableDictionaryTests.Message, MapTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ImmutableDictionary<int, string> Property { get; set; } =
+            System.Collections.Immutable.ImmutableDictionary<int, string>.Empty;
+
+        public override string ToString()
+        {
+            return string.Join(",", Property.Select(x => $"{x.Key}:{x.Value}"));
+        }
+    }
+
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = ImmutableDictionary<int, string>.Empty };
+        yield return new()
+        {
+            Property = new Dictionary<int, string>()
+            {
+                [1] = "one",
+                [2] = "two",
+                [3] = "three",
+            }.ToImmutableDictionary(),
+        };
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override IEnumerable<MapTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new MapTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(MapTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(
+            bytes,
+            new ImmutableDictionaryProtoReader<int, string>(
+                Int32ProtoParser.ProtoReader,
+                StringProtoParser.ProtoReader,
+                0
+            )
+        );
+        await Assert.That(deserialized.Count).IsEqualTo(0);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ImmutableHashSetTests.cs
+++ b/tests/LightProto.Tests/Parsers/ImmutableHashSetTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ImmutableHashSetTests
+    : BaseTests<ImmutableHashSetTests.Message, ArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ImmutableHashSet<int> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property)}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = [1, 2, 3, 4, 5] };
+        yield return new() { Property = [-1, -2, -3, -4, -5] };
+        yield return new() { Property = [0, 0, 0, 0, 0] };
+        yield return new() { Property = [0] };
+        yield return new() { Property = [] };
+    }
+
+    public override IEnumerable<ArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ArrayTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(ArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(
+            bytes,
+            new ImmutableHashSetProtoReader<int>(Int32ProtoParser.ProtoReader, 0)
+        );
+        await Assert.That(deserialized.Count).IsEqualTo(0);
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ImmutableListTests.cs
+++ b/tests/LightProto.Tests/Parsers/ImmutableListTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ImmutableListTests : BaseTests<ImmutableListTests.Message, ArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ImmutableList<int> Property { get; set; } = [];
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property)}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = [1, 2, 3, 4, 5] };
+        yield return new() { Property = [-1, -2, -3, -4, -5] };
+        yield return new() { Property = [0, 0, 0, 0, 0] };
+        yield return new() { Property = [0] };
+        yield return new() { Property = [] };
+    }
+
+    public override IEnumerable<ArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ArrayTestsMessage() { Property = { o.Property } });
+    }
+
+    public override async Task AssertGoogleResult(ArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property);
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(
+            bytes,
+            new ImmutableListProtoReader<int>(Int32ProtoParser.ProtoReader, 0)
+        );
+        await Assert.That(deserialized.Count).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
Introduced proto readers and writers for ImmutableArray, ImmutableList, ImmutableHashSet, and ImmutableDictionary in LightProto. Added corresponding tests to ensure correct serialization and deserialization. Updated project dependencies to include System.Collections.Immutable.

Closes: #114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added serialization and deserialization support for immutable collection types: ImmutableArray, ImmutableDictionary, ImmutableHashSet, and ImmutableList.

* **Tests**
  * Added comprehensive test coverage for immutable collection serialization and deserialization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->