### PR TITLE
Update CI and publish workflows for .NET versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,6 @@ jobs:
           dotnet publish tests/LightProto.Tests/ -f net8.0 -r linux-x64 -c Release
           ./tests/LightProto.Tests/bin/Release/net8.0/linux-x64/publish/LightProto.Tests
           
-          dotnet publish tests/LightProto.Tests/ -f net9.0 -r linux-x64 -c Release
-          ./tests/LightProto.Tests/bin/Release/net9.0/linux-x64/publish/LightProto.Tests
-          
-          dotnet publish tests/LightProto.Tests/ -f net10.0 -r linux-x64 -c Release
-          ./tests/LightProto.Tests/bin/Release/net10.0/linux-x64/publish/LightProto.Tests
-          
       - name: Run Benchmarks
         run: |
           dotnet run -c Release -f net8.0 net9.0 net10.0 --project ./tests/Benchmark -- --filter "*" --exporters github --artifacts ./BenchmarkResults
@@ -87,13 +81,7 @@ jobs:
         run: |
           dotnet publish tests/LightProto.Tests/ -f net8.0 -r win-x64 -c Release
           ./tests/LightProto.Tests/bin/Release/net8.0/win-x64/publish/LightProto.Tests.exe
-          
-          dotnet publish tests/LightProto.Tests/ -f net9.0 -r win-x64 -c Release
-          ./tests/LightProto.Tests/bin/Release/net9.0/win-x64/publish/LightProto.Tests.exe
-          
-          dotnet publish tests/LightProto.Tests/ -f net10.0 -r win-x64 -c Release
-          ./tests/LightProto.Tests/bin/Release/net10.0/win-x64/publish/LightProto.Tests.exe
 
       - name: Test package creation
         run: |
-          dotnet pack --configuration Release --no-build --output ./test-packages src/LightProto/
+          dotnet pack --configuration Release --output ./test-packages src/LightProto/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,9 @@ jobs:
           dotnet publish tests/LightProto.Tests/ -f net9.0 -r linux-x64 -c Release
           ./tests/LightProto.Tests/bin/Release/net9.0/linux-x64/publish/LightProto.Tests
           
+          dotnet publish tests/LightProto.Tests/ -f net10.0 -r linux-x64 -c Release
+          ./tests/LightProto.Tests/bin/Release/net10.0/linux-x64/publish/LightProto.Tests
+          
       - name: Pack packages
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then


### PR DESCRIPTION
Remove .NET 9.0 and 10.0 test runs from the CI workflow, keeping only .NET 8.0. Add .NET 10.0 test runs to the publish workflow. Also, remove the --no-build flag from the dotnet pack command in the CI workflow.