### PR TITLE
Change the max message size limit from `int.MaxValue` to `long.MaxValue`

### DIFF
--- a/src/LightProto/CodedInputStream.cs
+++ b/src/LightProto/CodedInputStream.cs
@@ -34,7 +34,7 @@ namespace LightProto
         /// </summary>
         private readonly bool leaveOpen;
 
-        internal int leftSize;
+        internal long leftSize;
 
         /// <summary>
         /// Buffer of data read from the stream or provided at construction time.
@@ -54,7 +54,7 @@ namespace LightProto
         private ParserInternalState state;
 
         internal const int DefaultRecursionLimit = 100;
-        internal const int DefaultSizeLimit = Int32.MaxValue;
+        internal const long DefaultSizeLimit = long.MaxValue;
         internal const int BufferSize = 4096;
 
         #region Construction
@@ -67,7 +67,7 @@ namespace LightProto
         /// <c cref="CodedInputStream"/> is disposed; <c>false</c> to dispose of the given stream when the
         /// returned object is disposed.</param>
         /// <param name="maxSize"></param>
-        internal CodedInputStream(Stream input, bool leaveOpen, int maxSize = int.MaxValue)
+        internal CodedInputStream(Stream input, bool leaveOpen, long maxSize = long.MaxValue)
             : this(
                 ProtoPreconditions.CheckNotNull(input, "input"),
                 new byte[BufferSize],
@@ -87,7 +87,7 @@ namespace LightProto
             int bufferPos,
             int bufferSize,
             bool leaveOpen,
-            int maxSize
+            long maxSize
         )
         {
             this.input = input;
@@ -98,7 +98,7 @@ namespace LightProto
             this.state.recursionLimit = DefaultRecursionLimit;
             SegmentedBufferHelper.Initialize(this, out this.state.segmentedBufferHelper);
             this.leaveOpen = leaveOpen;
-            this.state.currentLimit = int.MaxValue;
+            this.state.currentLimit = DefaultSizeLimit;
             this.leftSize = maxSize;
         }
 

--- a/src/LightProto/LightProto.csproj
+++ b/src/LightProto/LightProto.csproj
@@ -22,7 +22,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Version>999.999.999-localbuild</Version>
+    <Version>999.999.999-localbuild3</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/src/LightProto/Parser/Array.cs
+++ b/src/LightProto/Parser/Array.cs
@@ -44,7 +44,7 @@ public sealed class ArrayProtoReader<TItem> : ICollectionReader<TItem[], TItem>
             int length = ctx.ReadLength();
             if (length <= 0)
                 return [];
-            int oldLimit = SegmentedBufferHelper.PushLimit(ref ctx.state, length);
+            var oldLimit = SegmentedBufferHelper.PushLimit(ref ctx.state, length);
 
             try
             {

--- a/src/LightProto/Parser/IEnumerableReader.cs
+++ b/src/LightProto/Parser/IEnumerableReader.cs
@@ -57,10 +57,10 @@ public class IEnumerableProtoReader<TCollection, TItem> : ICollectionReader<TCol
             && PackedRepeated.Support<TItem>()
         )
         {
-            int length = ctx.ReadLength();
+            var length = ctx.ReadInt64();
             if (length <= 0)
                 return CreateWithCapacity(0);
-            int oldLimit = SegmentedBufferHelper.PushLimit(ref ctx.state, length);
+            var oldLimit = SegmentedBufferHelper.PushLimit(ref ctx.state, length);
 
             try
             {
@@ -76,7 +76,7 @@ public class IEnumerableProtoReader<TCollection, TItem> : ICollectionReader<TCol
                 )
                 {
                     var count = length / fixedSize;
-                    var collection = CreateWithCapacity(count);
+                    var collection = CreateWithCapacity((int)count);
                     // if littleEndian treat array as bytes and directly copy from buffer for improved performance
                     // if (
                     //     collection is List<TItem> list

--- a/src/LightProto/ParserInternalState.cs
+++ b/src/LightProto/ParserInternalState.cs
@@ -34,14 +34,14 @@ namespace LightProto
         /// <summary>
         /// The absolute position of the end of the current length-delimited block (including totalBytesRetired)
         /// </summary>
-        internal int currentLimit;
+        internal long currentLimit;
 
         /// <summary>
         /// The total number of consumed before the start of the current buffer. The
         /// total bytes read up to the current position can be computed as
         /// totalBytesRetired + bufferPos.
         /// </summary>
-        internal int totalBytesRetired;
+        internal long totalBytesRetired;
 
         internal int recursionDepth; // current recursion depth
 
@@ -60,7 +60,7 @@ namespace LightProto
         internal bool hasNextTag;
 
         // these fields are configuration, they should be readonly
-        internal int sizeLimit;
+        internal long sizeLimit;
         internal int recursionLimit;
 
         /// <summary>

--- a/src/LightProto/ParsingPrimitives.cs
+++ b/src/LightProto/ParsingPrimitives.cs
@@ -460,7 +460,7 @@ namespace LightProto
         public static byte[] ReadRawBytes(
             ref ReadOnlySpan<byte> buffer,
             ref ParserInternalState state,
-            int size
+            long size
         )
         {
             if (size < 0)
@@ -472,8 +472,8 @@ namespace LightProto
             {
                 // We have all the bytes we need already.
                 byte[] bytes = new byte[size];
-                buffer.Slice(state.bufferPos, size).CopyTo(bytes);
-                state.bufferPos += size;
+                buffer.Slice(state.bufferPos, (int)size).CopyTo(bytes);
+                state.bufferPos += (int)size;
                 return bytes;
             }
 
@@ -483,7 +483,7 @@ namespace LightProto
         private static byte[] ReadRawBytesSlow(
             ref ReadOnlySpan<byte> buffer,
             ref ParserInternalState state,
-            int size
+            long size
         )
         {
             ValidateCurrentLimit(ref buffer, ref state, size);
@@ -497,7 +497,7 @@ namespace LightProto
                 // of bytes.  We can safely allocate the resulting array ahead of time.
 
                 byte[] bytes = new byte[size];
-                ReadRawBytesIntoSpan(ref buffer, ref state, size, bytes);
+                ReadRawBytesIntoSpan(ref buffer, ref state, (int)size, bytes);
                 return bytes;
             }
             else
@@ -519,7 +519,7 @@ namespace LightProto
                 state.bufferPos = state.bufferSize;
 
                 // Read all the rest of the bytes we need.
-                int sizeLeft = size - pos;
+                var sizeLeft = size - pos;
                 while (sizeLeft > 0)
                 {
                     state.segmentedBufferHelper.RefillBuffer(ref buffer, ref state, true);
@@ -553,7 +553,7 @@ namespace LightProto
         public static void SkipRawBytes(
             ref ReadOnlySpan<byte> buffer,
             ref ParserInternalState state,
-            int size
+            long size
         )
         {
             if (size < 0)
@@ -566,12 +566,12 @@ namespace LightProto
             if (size <= state.bufferSize - state.bufferPos)
             {
                 // We have all the bytes we need already.
-                state.bufferPos += size;
+                state.bufferPos += (int)size;
             }
             else
             {
                 // Skipping more bytes than are in the buffer.  First skip what we have.
-                int pos = state.bufferSize - state.bufferPos;
+                long pos = state.bufferSize - state.bufferPos;
                 state.bufferPos = state.bufferSize;
 
                 // TODO: If our segmented buffer is backed by a Stream that is seekable, we could skip the bytes more efficiently
@@ -586,7 +586,7 @@ namespace LightProto
                     state.segmentedBufferHelper.RefillBuffer(ref buffer, ref state, true);
                 }
 
-                state.bufferPos = size - pos;
+                state.bufferPos = (int)(size - pos);
             }
         }
 
@@ -731,7 +731,7 @@ namespace LightProto
         private static void ValidateCurrentLimit(
             ref ReadOnlySpan<byte> buffer,
             ref ParserInternalState state,
-            int size
+            long size
         )
         {
             if (state.totalBytesRetired + state.bufferPos + size > state.currentLimit)
@@ -793,7 +793,7 @@ namespace LightProto
         /// When parsing from a Stream this can return false because we have no knowledge of the amount
         /// of data remaining in the stream until it is read.
         /// </summary>
-        public static bool IsDataAvailable(ref ParserInternalState state, int size)
+        public static bool IsDataAvailable(ref ParserInternalState state, long size)
         {
             // Data fits in remaining buffer
             if (size <= state.bufferSize - state.bufferPos)
@@ -810,7 +810,7 @@ namespace LightProto
         /// When parsing from a Stream this will return false because we have no knowledge of the amount
         /// of data remaining in the stream until it is read.
         /// </summary>
-        private static bool IsDataAvailableInSource(ref ParserInternalState state, int size)
+        private static bool IsDataAvailableInSource(ref ParserInternalState state, long size)
         {
             // Data fits in remaining source data.
             // Note that this will never be true when reading from a stream as the total length is unknown.

--- a/src/LightProto/SegmentedBufferHelper.cs
+++ b/src/LightProto/SegmentedBufferHelper.cs
@@ -105,14 +105,14 @@ namespace LightProto
         /// limit is returned.
         /// </summary>
         /// <returns>The old limit.</returns>
-        public static int PushLimit(ref ParserInternalState state, int byteLimit)
+        public static long PushLimit(ref ParserInternalState state, long byteLimit)
         {
             if (byteLimit < 0)
             {
                 throw InvalidProtocolBufferException.NegativeSize();
             }
             byteLimit += state.totalBytesRetired + state.bufferPos;
-            int oldLimit = state.currentLimit;
+            var oldLimit = state.currentLimit;
             if (byteLimit > oldLimit)
             {
                 throw InvalidProtocolBufferException.TruncatedMessage();
@@ -127,7 +127,7 @@ namespace LightProto
         /// <summary>
         /// Discards the current limit, returning the previous limit.
         /// </summary>
-        public static void PopLimit(ref ParserInternalState state, int oldLimit)
+        public static void PopLimit(ref ParserInternalState state, long oldLimit)
         {
             state.currentLimit = oldLimit;
             RecomputeBufferSizeAfterLimit(ref state);
@@ -143,7 +143,7 @@ namespace LightProto
             {
                 return false;
             }
-            int currentAbsolutePosition = state.totalBytesRetired + state.bufferPos;
+            long currentAbsolutePosition = state.totalBytesRetired + state.bufferPos;
             return currentAbsolutePosition >= state.currentLimit;
         }
 
@@ -208,7 +208,7 @@ namespace LightProto
             else
             {
                 RecomputeBufferSizeAfterLimit(ref state);
-                int totalBytesRead =
+                long totalBytesRead =
                     state.totalBytesRetired + state.bufferSize + state.bufferSizeAfterLimit;
                 if (totalBytesRead < 0 || totalBytesRead > state.sizeLimit)
                 {
@@ -245,7 +245,7 @@ namespace LightProto
             state.totalBytesRetired += state.bufferSize;
 
             state.bufferPos = 0;
-            int bytesToRead = Math.Min(buffer.Length, codedInputStream.leftSize);
+            int bytesToRead = (int)Math.Min(buffer.Length, codedInputStream.leftSize);
             if (bytesToRead == 0)
             {
                 state.bufferSize = 0;
@@ -273,7 +273,7 @@ namespace LightProto
             else
             {
                 RecomputeBufferSizeAfterLimit(ref state);
-                int totalBytesRead =
+                long totalBytesRead =
                     state.totalBytesRetired + state.bufferSize + state.bufferSizeAfterLimit;
                 if (totalBytesRead < 0 || totalBytesRead > state.sizeLimit)
                 {
@@ -286,11 +286,11 @@ namespace LightProto
         private static void RecomputeBufferSizeAfterLimit(ref ParserInternalState state)
         {
             state.bufferSize += state.bufferSizeAfterLimit;
-            int bufferEnd = state.totalBytesRetired + state.bufferSize;
+            long bufferEnd = state.totalBytesRetired + state.bufferSize;
             if (bufferEnd > state.currentLimit)
             {
                 // Limit is in current buffer.
-                state.bufferSizeAfterLimit = bufferEnd - state.currentLimit;
+                state.bufferSizeAfterLimit = (int)(bufferEnd - state.currentLimit);
                 state.bufferSize -= state.bufferSizeAfterLimit;
             }
             else

--- a/src/LightProto/Serializer.Extensions.cs
+++ b/src/LightProto/Serializer.Extensions.cs
@@ -48,13 +48,13 @@ public static partial class Serializer
     {
         if (reader.IsMessage)
         {
-            int length = ParsingPrimitives.ParseLength(ref input.buffer, ref input.state);
+            var length = input.ReadInt64();
             if (input.state.recursionDepth >= input.state.recursionLimit)
             {
                 throw InvalidProtocolBufferException.RecursionLimitExceeded();
             }
 
-            int oldLimit = SegmentedBufferHelper.PushLimit(ref input.state, length);
+            var oldLimit = SegmentedBufferHelper.PushLimit(ref input.state, length);
             ++input.state.recursionDepth;
             var message = reader.ParseFrom(ref input);
 

--- a/tests/LightProto.Tests/FailedTests.cs
+++ b/tests/LightProto.Tests/FailedTests.cs
@@ -88,7 +88,7 @@ public partial class FailedTests
     {
         var ex = await Assert.ThrowsAsync<InvalidProtocolBufferException>(async () =>
         {
-            var bytes = new byte[] { 10, 255, 255, 255, 255, 255, 255, 255, 255, 1, 16, 1 };
+            var bytes = new byte[] { 10, 199, 159, 255, 255, 255, 255, 255, 255, 255, 1, 16, 1 };
             var strings = Serializer.Deserialize<TestContract>(bytes);
             await Task.CompletedTask;
         });


### PR DESCRIPTION
Updated various internal fields, method parameters, and logic from int to long to support larger message and buffer sizes. This change affects parsing, buffer management, and serialization logic to improve compatibility with large data. Also updated a test case to use a new byte sequence.

This pull request updates the LightProto codebase to use `long` (64-bit) instead of `int` (32-bit) for all size and length-related fields, parameters, and calculations throughout the parsing and serialization logic. This change enables support for much larger messages and data streams, removing previous 2GB size limitations. The update touches core parsing logic, buffer management, and related APIs, as well as associated tests.

**Core parsing and buffer logic:**

* Changed all size, length, and limit fields and parameters from `int` to `long` in `CodedInputStream`, `ParserInternalState`, and related parsing methods and helpers, allowing support for messages and buffers larger than 2GB. [[1]](diffhunk://#diff-b3f61307f94c7b92d3d3d9f6691c2a75b3a1c3f8fb940b34ae0d3f051cc84f9cL37-R37) [[2]](diffhunk://#diff-b3f61307f94c7b92d3d3d9f6691c2a75b3a1c3f8fb940b34ae0d3f051cc84f9cL57-R57) [[3]](diffhunk://#diff-b3f61307f94c7b92d3d3d9f6691c2a75b3a1c3f8fb940b34ae0d3f051cc84f9cL70-R70) [[4]](diffhunk://#diff-b3f61307f94c7b92d3d3d9f6691c2a75b3a1c3f8fb940b34ae0d3f051cc84f9cL90-R90) [[5]](diffhunk://#diff-b3f61307f94c7b92d3d3d9f6691c2a75b3a1c3f8fb940b34ae0d3f051cc84f9cL101-R101) [[6]](diffhunk://#diff-0373f8314a2a2c22f0ff0adc073826542933a7b8594d15578cb1263e999c1a45L37-R44) [[7]](diffhunk://#diff-0373f8314a2a2c22f0ff0adc073826542933a7b8594d15578cb1263e999c1a45L63-R63) [[8]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L463-R463) [[9]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L486-R486) [[10]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L556-R556) [[11]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L734-R734) [[12]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L796-R796) [[13]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L813-R813) [[14]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L108-R115) [[15]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L130-R130) [[16]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L146-R146) [[17]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L211-R211) [[18]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L276-R276) [[19]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L289-R293)

* Updated buffer and position calculations to safely cast between `long` and `int` when interacting with arrays and spans, ensuring compatibility with .NET APIs that require `int` sizes. [[1]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L475-R476) [[2]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L500-R500) [[3]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L569-R574) [[4]](diffhunk://#diff-9d2d07f9e19551ba3b7dc64078b34b1c14b4be441b9161dad010c15bca663ec6L589-R589) [[5]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L248-R248) [[6]](diffhunk://#diff-3d15b44d7045978a3beb366538d31f19197fb6220bebe16ec50fed441e2b7461L289-R293)

**Parsing and serialization APIs:**

* Updated parsing methods in array and collection readers to use `long` for lengths and limits, and cast to `int` where necessary for collection allocation. [[1]](diffhunk://#diff-7a1d975d712e7027b25113008211ff0bc8dd70cf3825e658aca46775867d2659L47-R47) [[2]](diffhunk://#diff-bff196c531c11dca039c77ccbcb4587253e9fe314a6338aab3a045b7d91c8357L60-R63) [[3]](diffhunk://#diff-bff196c531c11dca039c77ccbcb4587253e9fe314a6338aab3a045b7d91c8357L79-R79) [[4]](diffhunk://#diff-0f4a9145785fa93f3cd0263fdef4688824a15c6d9bdfc75f43772201cce3796cL51-R57)

**Test and project metadata:**

* Adjusted test data in `FailedTests.cs` to match new length encoding expectations for negative size handling.
* Updated the package version in the project file for local build tracking.