### PR TITLE
Enable Source Link for better debugging experience

### DIFF
--- a/src/LightProto/LightProto.csproj
+++ b/src/LightProto/LightProto.csproj
@@ -59,4 +59,14 @@
     <AdditionalFiles Include="PublicAPI/net/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/net/PublicAPI.Unshipped.txt" />
   </ItemGroup>
+  <!-- Enable Source Link for better debugging experience -->
+  <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request improves the debugging experience for the `LightProto` project by enabling Source Link and configuring symbol package generation. These changes will make it easier to debug into the source code when using the library from NuGet.

Build and debugging improvements:

* Enabled deterministic builds, continuous integration build settings, and symbol package generation (`snupkg`) in the project file (`LightProto.csproj`).
* Added a package reference to `Microsoft.SourceLink.GitHub` to support Source Link integration for better debugging with source code.