### PR TITLE
Add diagnostics for attribute misuse and improve validation

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -6,7 +6,7 @@ Member has default value which may break deserialization.
 
 ```csharp
 [ProtoContract]
-public class MyClass
+public partial class MyClass
 {
     [ProtoMember(1)]
     public int MyValue { get; set; } = 42; // Warning: LIGHT_PROTO_W001
@@ -25,3 +25,222 @@ This behavior is consistent with **protobuf-net**.
 
 1. Use `[ProtoContract(SkipConstructor = true)]` to avoid invoking the default constructor.
 2. Avoid assigning default values to members.
+
+## LIGHT_PROTO_W002
+
+Member is marked as IsPacked but is not a collection type
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1, IsPacked = true)] // Warning: LIGHT_PROTO_W002
+    public int MyValue { get; set; }
+}
+```
+
+The cause of this issue is that the `IsPacked` option is only applicable to collection types (e.g., arrays, lists). Applying it to a non-collection type like `int` is incorrect and will be ignored.
+
+## LIGHT_PROTO_W003
+
+Member is marked as IsPacked but the item type does not support packed encoding
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1, IsPacked = true)] // Warning: LIGHT_PROTO_W003
+    public List<string> MyStrings { get; set; }
+}
+```
+The cause of this issue is that the `IsPacked` option is only applicable to numeric types (e.g., int, float). Applying it to non-numeric types like `string` is incorrect and will be ignored.
+
+Supported packed types include:
+
+- Boolean(`bool`)
+- Int16(`short`)
+- UInt16(`ushort`)
+- Int32(`int`)
+- UInt32(`uint`)
+- Int64(`long`)
+- UInt64(`ulong`)
+- Byte(`byte`)
+- SByte(`sbyte`)
+- Single(`float`)
+- Double(`double`)
+- Char(`char`)
+- Enum(`enum`)
+
+## LIGHT_PROTO_W004
+
+StringInternAttribute applied to non-string type
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1), StringIntern] // Warning: LIGHT_PROTO_W004
+    public int MyValue { get; set; }
+}
+```
+The cause of this issue is that the `StringIntern` attribute is only applicable to string types. Applying it to non-string types like `int` is incorrect and will be ignored.
+
+## LIGHT_PROTO_W005
+
+CompatibilityLevel.Level240 only supports DateTime and TimeSpan for well-known types
+
+```csharp
+[ProtoContract()]
+public partial class MyClass
+{
+    [ProtoMember(1)]
+    [CompatibilityLevel(CompatibilityLevel.Level240)]
+    public Guid MyGuid { get; set; } // Warning: LIGHT_PROTO_W005
+}
+
+```
+
+The cause of this issue is that when using `CompatibilityLevel.Level240`, only `DateTime` and `TimeSpan` are supported as well-known types. Using other types like `Guid` is not supported and will be ignored.
+
+## LIGHT_PROTO_W006
+
+CompatibilityLevel.Level300 only supports Decimal and Guid for well-known types
+
+```csharp
+[ProtoContract()]
+public partial class MyClass
+{
+    [ProtoMember(1)]
+    [CompatibilityLevel(CompatibilityLevel.Level300)]
+    public DateTime MyDateTime { get; set; } // Warning: LIGHT_PROTO_W006
+}
+```
+
+The cause of this issue is that when using `CompatibilityLevel.Level300`, only `Decimal` and `Guid` are supported as well-known types. Using other types like `DateTime` is not supported and will be ignored.
+
+## LIGHT_PROTO_W007
+
+Member has DataFormat.ZigZag but the type does not support it
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1, DataFormat = DataFormat.ZigZag)] // Warning: LIGHT_PROTO_W007
+    public uint MyValue { get; set; }
+}
+```
+The cause of this issue is that the `DataFormat.ZigZag` option is only applicable to signed integer types (e.g., `int`, `long`, `short`). Applying it to unsigned types like `uint` is incorrect and will be ignored.
+
+Supported ZigZag types include:
+- SByte(`sbyte`)
+- Int16(`short`)
+- Int32(`int`)
+- Int64(`long`)
+
+## LIGHT_PROTO_W008
+
+Member has DataFormat.FixedSize but the type does not support it
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1, DataFormat = DataFormat.FixedSize)] // Warning: LIGHT_PROTO_W008
+    public string MyValue { get; set; }
+}
+```
+The cause of this issue is that the `DataFormat.FixedSize` option is only applicable to fixed-size types (e.g., `float`, `double`, `int`, `long`). Applying it to non-fixed-size types like `string` is incorrect and will be ignored.
+
+Supported FixedSize types include:
+- SByte(`sbyte`)
+- Int16(`short`)
+- Int32(`int`)
+- Int64(`long`)
+- Byte(`byte`)
+- UInt16(`ushort`)
+- UInt32(`uint`)
+- UInt64(`ulong`)
+
+`float` and `double` are not checked because they always use fixed-size encoding.
+
+## LIGHT_PROTO_W009
+
+Member has ProtoMapAttribute but is not a dictionary type
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1)] 
+    [ProtoMap(KeyFormat = DataFormat.ZigZag, ValueFormat = DataFormat.FixedSize)] // Warning: LIGHT_PROTO_W009
+    public List<int> MyValues { get; set; }
+}
+```
+
+The cause of this issue is that the `ProtoMap` attribute is only applicable to dictionary types (e.g., `Dictionary<TKey, TValue>`). Applying it to non-dictionary types like `List<int>` is incorrect and will be ignored.
+
+## LIGHT_PROTO_W010
+
+Member has ProtoMapAttribute with DataFormat.ZigZag on key but the key type does not support it
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1)] 
+    [ProtoMap(KeyFormat = DataFormat.ZigZag, ValueFormat = DataFormat.Default)] // Warning: LIGHT_PROTO_W010
+    public Dictionary<uint, string> MyMap { get; set; }
+}
+```
+The cause of this issue is that the `DataFormat.ZigZag` option on the key is only applicable to signed integer types (e.g., `int`, `long`, `short`). Applying it to unsigned types like `uint` is incorrect and will be ignored.
+
+Supported ZigZag types can be found in the [LIGHT_PROTO_W007](#light_proto_w007) section.
+
+## LIGHT_PROTO_W011
+
+Member has ProtoMapAttribute with DataFormat.FixedSize on key but the key type does not support it
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1)] 
+    [ProtoMap(KeyFormat = DataFormat.FixedSize, ValueFormat = DataFormat.Default)] // Warning: LIGHT_PROTO_W011
+    public Dictionary<string, int> MyMap { get; set; }
+}
+```
+The cause of this issue is that the `DataFormat.FixedSize` option on the key is only applicable to fixed-size types (e.g., `float`, `double`, `int`, `long`). Applying it to non-fixed-size types like `string` is incorrect and will be ignored.
+
+Supported FixedSize types can be found in the [LIGHT_PROTO_W008](#light_proto_w008) section.
+
+## LIGHT_PROTO_W012
+
+Member has ProtoMapAttribute with DataFormat.ZigZag on value but the value type does not support it
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1)] 
+    [ProtoMap(KeyFormat = DataFormat.Default, ValueFormat = DataFormat.ZigZag)] // Warning: LIGHT_PROTO_W012
+    public Dictionary<string, uint> MyMap { get; set; }
+}
+```
+The cause of this issue is that the `DataFormat.ZigZag` option on the value is only applicable to signed integer types (e.g., `int`, `long`, `short`). Applying it to unsigned types like `uint` is incorrect and will be ignored.
+
+Supported ZigZag types can be found in the [LIGHT_PROTO_W007](#light_proto_w007) section.
+
+## LIGHT_PROTO_W013
+
+Member has ProtoMapAttribute with DataFormat.FixedSize on value but the value type does not support it
+
+```csharp
+[ProtoContract]
+public partial class MyClass
+{
+    [ProtoMember(1)] 
+    [ProtoMap(KeyFormat = DataFormat.Default, ValueFormat = DataFormat.FixedSize)] // Warning: LIGHT_PROTO_W013
+    public Dictionary<string, string> MyMap { get; set; }
+}
+```
+The cause of this issue is that the `DataFormat.FixedSize` option on the value is only applicable to fixed-size types (e.g., `float`, `double`, `int`, `long`). Applying it to non-fixed-size types like `string` is incorrect and will be ignored.
+
+Supported FixedSize types can be found in the [LIGHT_PROTO_W008](#light_proto_w008) section.

--- a/src/LightProto.Generator/LightProtoGeneratorException.cs
+++ b/src/LightProto.Generator/LightProtoGeneratorException.cs
@@ -232,4 +232,18 @@ internal class LightProtoGeneratorException(string message) : Exception(message)
             Location = getLocation,
         };
     }
+
+    public static Exception ProtoInclude_DerivedType_Tag_Conflicts_With_Member(string toDisplayString, uint result, Location? getLocation)
+    {
+        return new LightProtoGeneratorException(
+            $"Derived type in ProtoInclude attribute {toDisplayString} tag {result} conflicts with member tag"
+        )
+        {
+            Id = "LIGHT_PROTO_019",
+            Title = $"Derived type in ProtoInclude attribute tag conflicts with member tag",
+            Category = "Usage",
+            Severity = DiagnosticSeverity.Error,
+            Location = getLocation,
+        };
+    }
 }

--- a/src/LightProto.Generator/LightProtoGeneratorWarning.cs
+++ b/src/LightProto.Generator/LightProtoGeneratorWarning.cs
@@ -246,7 +246,7 @@ internal static class LightProtoGeneratorWarning
                 category: "Usage",
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true,
-                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w012"
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w013"
             ),
             memberLocations.FirstOrDefault() ?? Location.None,
             additionalLocations: memberLocations.Skip(1),

--- a/src/LightProto.Generator/LightProtoGeneratorWarning.cs
+++ b/src/LightProto.Generator/LightProtoGeneratorWarning.cs
@@ -22,4 +22,235 @@ internal static class LightProtoGeneratorWarning
             memberName
         );
     }
+
+    public static Diagnostic MemberIsPackedButNotCollection(string memberName, ImmutableArray<Location> locations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W002",
+                title: "Member is marked as IsPacked but is not a collection type",
+                messageFormat: "Member '{0}' is marked as IsPacked but is not a collection type. The IsPacked option will be ignored.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w002"
+            ),
+            locations.FirstOrDefault() ?? Location.None,
+            additionalLocations: locations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic MemberIsPackedButItemNotSupportPacked(string memberName, ImmutableArray<Location> locations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W003",
+                title: "Member is marked as IsPacked but the item type does not support packed encoding",
+                messageFormat: "Member '{0}' is marked as IsPacked but the item type does not support packed encoding. The IsPacked option will be ignored.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w003"
+            ),
+            locations.FirstOrDefault() ?? Location.None,
+            additionalLocations: locations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic StringInternAttribute_Applied_NonString_Type(string memberName, ImmutableArray<Location> memberLocations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W004",
+                title: "StringInternAttribute applied to non-string type",
+                messageFormat: "Member '{0}' is marked with StringInternAttribute but is not of type string. The attribute will be ignored.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w004"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic CompatibilityLevel240_Only_Support_DateTime_TimeSpan(
+        string memberName,
+        ImmutableArray<Location> memberLocations
+    )
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W005",
+                title: "CompatibilityLevel.Level240 only supports DateTime and TimeSpan for well-known types",
+                messageFormat: "Member '{0}' is of a well-known type that is not supported in CompatibilityLevel.Level240. Only DateTime and TimeSpan are supported.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w005"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic CompatibilityLevel300_Only_Support_Decimal_Guid(string memberName, ImmutableArray<Location> memberLocations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W006",
+                title: "CompatibilityLevel.Level300 only supports Decimal and Guid for well-known types",
+                messageFormat: "Member '{0}' is of a well-known type that is not supported in CompatibilityLevel.Level300. Only Decimal and Guid are supported.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w006"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_DataFormat_ZigZag_Not_Supported_Type(string memberName, ImmutableArray<Location> memberLocations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W007",
+                title: "Member has DataFormat.ZigZag but the type does not support it",
+                messageFormat: "Member '{0}' is marked with DataFormat.ZigZag but the type does not support it. The DataFormat.ZigZag option will be ignored.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w007"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_DataFormat_FixedSize_Not_Supported_Type(string memberName, ImmutableArray<Location> memberLocations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W008",
+                title: "Member has DataFormat.FixedSize but the type does not support it",
+                messageFormat: "Member '{0}' is marked with DataFormat.FixedSize but the type does not support it. The DataFormat.FixedSize option will be ignored.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w008"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_ProtoMapAttribute_But_Not_Dictionary(string memberName, ImmutableArray<Location> memberLocations)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W009",
+                title: "Member has ProtoMapAttribute but is not a dictionary type",
+                messageFormat: "Member '{0}' is marked with ProtoMapAttribute but is not a dictionary type. The ProtoMapAttribute will be ignored.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w009"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_ProtoMap_Key_DataFormat_ZigZag_Not_Supported_Type(
+        string memberName,
+        ImmutableArray<Location> memberLocations
+    )
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W010",
+                title: "Member has ProtoMapAttribute with DataFormat.ZigZag on key but the key type does not support it",
+                messageFormat: "Member '{0}' is marked with ProtoMapAttribute with DataFormat.ZigZag on key but the key type does not support it. The DataFormat.ZigZag option will be ignored for the key.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w010"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_ProtoMap_Key_DataFormat_FixedSize_Not_Supported_Type(
+        string memberName,
+        ImmutableArray<Location> memberLocations
+    )
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W011",
+                title: "Member has ProtoMapAttribute with DataFormat.FixedSize on key but the key type does not support it",
+                messageFormat: "Member '{0}' is marked with ProtoMapAttribute with DataFormat.FixedSize on key but the key type does not support it. The DataFormat.FixedSize option will be ignored for the key.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w011"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_ProtoMap_Value_DataFormat_ZigZag_Not_Supported_Type(
+        string memberName,
+        ImmutableArray<Location> memberLocations
+    )
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W012",
+                title: "Member has ProtoMapAttribute with DataFormat.ZigZag on value but the value type does not support it",
+                messageFormat: "Member '{0}' is marked with ProtoMapAttribute with DataFormat.ZigZag on value but the value type does not support it. The DataFormat.ZigZag option will be ignored for the value.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w012"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
+
+    public static Diagnostic Member_ProtoMap_Value_DataFormat_FixedSize_Not_Supported_Type(
+        string memberName,
+        ImmutableArray<Location> memberLocations
+    )
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id: "LIGHT_PROTO_W013",
+                title: "Member has ProtoMapAttribute with DataFormat.FixedSize on value but the value type does not support it",
+                messageFormat: "Member '{0}' is marked with ProtoMapAttribute with DataFormat.FixedSize on value but the value type does not support it. The DataFormat.FixedSize option will be ignored for the value.",
+                category: "Usage",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true,
+                helpLinkUri: "https://github.com/dameng324/LightProto/blob/main/docs/Diagnostics.md#light_proto_w012"
+            ),
+            memberLocations.FirstOrDefault() ?? Location.None,
+            additionalLocations: memberLocations.Skip(1),
+            memberName
+        );
+    }
 }

--- a/src/LightProto.Generator/ProtoContract.cs
+++ b/src/LightProto.Generator/ProtoContract.cs
@@ -390,7 +390,7 @@ class ProtoContract
             {
                 if (Helper.IsCollectionType(compilation, memberType, out var itemType))
                 {
-                    if (Helper.SupportsPackedEncoding(compilation, itemType) == false)
+                    if (!Helper.SupportsPackedEncoding(compilation, itemType))
                     {
                         spc.ReportDiagnostic(
                             LightProtoGeneratorWarning.MemberIsPackedButItemNotSupportPacked(
@@ -575,7 +575,7 @@ class ProtoContract
                 .GetAttributes()
                 .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "LightProto.ProtoMapAttribute");
 
-            if (protoMapAttr is not null && Helper.IsDictionaryType(compilation, memberType) == false)
+            if (protoMapAttr is not null && !Helper.IsDictionaryType(compilation, memberType))
             {
                 spc.ReportDiagnostic(
                     LightProtoGeneratorWarning.Member_ProtoMapAttribute_But_Not_Dictionary($"{targetType}.{member.Name}", member.Locations)

--- a/src/LightProto.Generator/ProtoContract.cs
+++ b/src/LightProto.Generator/ProtoContract.cs
@@ -49,7 +49,7 @@ class ProtoContract
         var typeDeclaration = (targetType.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as TypeDeclarationSyntax)!;
 
         var proxyFor = GetProxyFor(targetType.GetAttributes());
-
+        var members = GetProtoMembers(compilation, targetType, typeDeclaration, implicitFields, implicitFirstTag, skipConstructor, spc);
         var protoIncludeAttributes = targetType
             .GetAttributes()
             .Where(attr => attr.AttributeClass?.ToDisplayString() == "LightProto.ProtoIncludeAttribute")
@@ -107,7 +107,7 @@ class ProtoContract
                 );
             }
 
-            if (contract.Members.Any(x => x.FieldNumber == tag))
+            if (members.Any(x => x.FieldNumber == tag))
             {
                 throw LightProtoGeneratorException.ProtoInclude_DerivedType_Tag_Conflicts_With_Member(
                     derivedType.ToDisplayString(),
@@ -135,7 +135,7 @@ class ProtoContract
             Compilation = compilation,
             Type = targetType,
             TypeDeclaration = typeDeclaration,
-            Members = GetProtoMembers(compilation, targetType, typeDeclaration, implicitFields, implicitFirstTag, skipConstructor, spc),
+            Members = members,
             ImplicitFields = implicitFields,
             ImplicitFirstTag = implicitFirstTag,
             AttributeData = default,

--- a/src/LightProto.Generator/ProtoContract.cs
+++ b/src/LightProto.Generator/ProtoContract.cs
@@ -106,6 +106,16 @@ class ProtoContract
                     attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
                 );
             }
+
+            if (contract.Members.Any(x => x.FieldNumber == tag))
+            {
+                throw LightProtoGeneratorException.ProtoInclude_DerivedType_Tag_Conflicts_With_Member(
+                    derivedType.ToDisplayString(),
+                    tag,
+                    attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
+                );
+            }
+
             derivedTypeContracts.Add((rawTag, contract));
         }
 
@@ -376,6 +386,70 @@ class ProtoContract
                 }
             }
 
+            if (isPacked)
+            {
+                if (Helper.IsCollectionType(compilation, memberType, out var itemType))
+                {
+                    if (Helper.SupportsPackedEncoding(compilation, itemType) == false)
+                    {
+                        spc.ReportDiagnostic(
+                            LightProtoGeneratorWarning.MemberIsPackedButItemNotSupportPacked(
+                                $"{targetType}.{member.Name}",
+                                member.Locations
+                            )
+                        );
+                    }
+                }
+                else
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.MemberIsPackedButNotCollection($"{targetType}.{member.Name}", member.Locations)
+                    );
+                }
+            }
+
+            if (dataFormat is DataFormat.ZigZag)
+            {
+                if (Helper.SupportZigZag(memberType))
+                {
+                    //OK
+                }
+                else if (Helper.IsCollectionType(compilation, memberType, out var itemType) && Helper.SupportZigZag(itemType!))
+                {
+                    //OK
+                }
+                else
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.Member_DataFormat_ZigZag_Not_Supported_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+            }
+
+            if (dataFormat is DataFormat.FixedSize)
+            {
+                if (Helper.SupportFixedSize(memberType))
+                {
+                    //OK
+                }
+                else if (Helper.IsCollectionType(compilation, memberType, out var itemType) && Helper.SupportFixedSize(itemType!))
+                {
+                    //OK
+                }
+                else
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.Member_DataFormat_FixedSize_Not_Supported_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+            }
+
             bool HasEmptyStaticField(ITypeSymbol type)
             {
                 return type.GetMembers().OfType<IFieldSymbol>().Any(o => o.IsStatic && o.Name == "Empty");
@@ -388,11 +462,40 @@ class ProtoContract
                 return attributeDatas.Any(attr => attr.AttributeClass?.ToDisplayString() == "LightProto.StringInternAttribute");
             }
 
+            var memberStringIntern = HasStringInternAttribute(member.GetAttributes());
             bool stringIntern =
-                HasStringInternAttribute(member.GetAttributes())
+                memberStringIntern
                 || HasStringInternAttribute(targetType.GetAttributes())
                 || HasStringInternAttribute(targetType.ContainingModule.GetAttributes())
                 || HasStringInternAttribute(targetType.ContainingAssembly.GetAttributes());
+
+            if (memberStringIntern)
+            {
+                if (memberType.SpecialType == SpecialType.System_String)
+                {
+                    // OK
+                }
+                else if (memberType is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_String })
+                {
+                    // OK
+                }
+                else if (
+                    memberType is INamedTypeSymbol namedType
+                    && namedType.TypeArguments.Any(x => x.SpecialType == SpecialType.System_String)
+                )
+                {
+                    // OK
+                }
+                else
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.StringInternAttribute_Applied_NonString_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+            }
 
             AttributeData? GetCompatibilityLevelAttribute(IEnumerable<AttributeData> attributeDatas)
             {
@@ -401,8 +504,9 @@ class ProtoContract
                 );
             }
 
+            var memberCompatibilityLevelAttr = GetCompatibilityLevelAttribute(member.GetAttributes());
             AttributeData? compatibilityLevelAttr =
-                GetCompatibilityLevelAttribute(member.GetAttributes())
+                memberCompatibilityLevelAttr
                 ?? GetCompatibilityLevelAttribute(targetType.GetAttributes())
                 ?? GetCompatibilityLevelAttribute(targetType.ContainingModule.GetAttributes())
                 ?? GetCompatibilityLevelAttribute(targetType.ContainingAssembly.GetAttributes());
@@ -414,6 +518,50 @@ class ProtoContract
                 ? _compatibilityLevel
                 : CompatibilityLevel.Level200;
 
+            if (memberCompatibilityLevelAttr is not null)
+            {
+                if (compatibilityLevel == CompatibilityLevel.Level240)
+                {
+                    if (memberType.SpecialType is SpecialType.System_DateTime)
+                    {
+                        //OK
+                    }
+                    else if (Helper.IsTimeSpanType(memberType))
+                    {
+                        //OK
+                    }
+                    else
+                    {
+                        spc.ReportDiagnostic(
+                            LightProtoGeneratorWarning.CompatibilityLevel240_Only_Support_DateTime_TimeSpan(
+                                $"{targetType}.{member.Name}",
+                                member.Locations
+                            )
+                        );
+                    }
+                }
+                else if (compatibilityLevel == CompatibilityLevel.Level300)
+                {
+                    if (memberType.SpecialType is SpecialType.System_Decimal)
+                    {
+                        //OK
+                    }
+                    else if (Helper.IsGuidType(memberType))
+                    {
+                        //OK
+                    }
+                    else
+                    {
+                        spc.ReportDiagnostic(
+                            LightProtoGeneratorWarning.CompatibilityLevel300_Only_Support_Decimal_Guid(
+                                $"{targetType}.{member.Name}",
+                                member.Locations
+                            )
+                        );
+                    }
+                }
+            }
+
             if (
 #pragma warning disable CS0618 // Type or member is obsolete
                 dataFormat is DataFormat.WellKnown
@@ -422,9 +570,17 @@ class ProtoContract
             {
                 compatibilityLevel = CompatibilityLevel.Level240;
             }
+
             AttributeData? protoMapAttr = member
                 .GetAttributes()
                 .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString() == "LightProto.ProtoMapAttribute");
+
+            if (protoMapAttr is not null && Helper.IsDictionaryType(compilation, memberType) == false)
+            {
+                spc.ReportDiagnostic(
+                    LightProtoGeneratorWarning.Member_ProtoMapAttribute_But_Not_Dictionary($"{targetType}.{member.Name}", member.Locations)
+                );
+            }
 
             var keyFormat = Enum.TryParse<DataFormat>(
                 protoMapAttr?.NamedArguments.FirstOrDefault(kv => kv.Key == "KeyFormat").Value.Value?.ToString(),
@@ -439,6 +595,50 @@ class ProtoContract
             )
                 ? _valueFormat
                 : DataFormat.Default;
+
+            if (memberType is INamedTypeSymbol { TypeArguments: { Length: 2 } typeArguments })
+            {
+                var keyType = typeArguments[0];
+                if (keyFormat is DataFormat.ZigZag && !Helper.SupportZigZag(keyType))
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.Member_ProtoMap_Key_DataFormat_ZigZag_Not_Supported_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+                if (keyFormat is DataFormat.FixedSize && !Helper.SupportFixedSize(keyType))
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.Member_ProtoMap_Key_DataFormat_FixedSize_Not_Supported_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+
+                var valueType = typeArguments[1];
+                if (valueFormat is DataFormat.ZigZag && !Helper.SupportZigZag(valueType))
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.Member_ProtoMap_Value_DataFormat_ZigZag_Not_Supported_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+
+                if (valueFormat is DataFormat.FixedSize && !Helper.SupportFixedSize(valueType))
+                {
+                    spc.ReportDiagnostic(
+                        LightProtoGeneratorWarning.Member_ProtoMap_Value_DataFormat_FixedSize_Not_Supported_Type(
+                            $"{targetType}.{member.Name}",
+                            member.Locations
+                        )
+                    );
+                }
+            }
 
             if (members.Any(o => o.FieldNumber == tag))
             {


### PR DESCRIPTION
Introduces new warnings for incorrect usage of IsPacked, StringIntern, CompatibilityLevel, DataFormat, and ProtoMap attributes. Updates Helper methods to support new type checks, adds detailed diagnostics in LightProtoGeneratorWarning, and enforces validation logic in ProtoContract. Documentation is updated to describe new warnings and their causes.

Fixes: #165 

This pull request introduces comprehensive improvements to diagnostics and helper utilities in the LightProto codebase. It adds several new warning diagnostics for common attribute and type misuses, enhances helper methods to better support type analysis (especially for collection and encoding support), and updates the documentation accordingly. These changes improve developer feedback and code safety when using LightProto attributes.

The most important changes are:

**Diagnostics and Warnings:**

* Added new warning diagnostics in `LightProtoGeneratorWarning.cs` for various attribute misuses, such as using `IsPacked` on non-collection or unsupported types, incorrect application of `StringIntern`, and misuse of `ProtoMap` and `DataFormat` options. Each warning includes a unique ID and a link to detailed documentation.
* Added a new error diagnostic for conflicts between `ProtoInclude` derived type tags and member tags in `LightProtoGeneratorException.cs`.

**Helper Methods and Type Analysis:**

* Extended `IsCollectionType` in `Helper.cs` to return the item type via an out parameter, and added new helpers: `SupportsPackedEncoding`, `SupportFixedSize`, and `SupportZigZag` for checking encoding compatibility. [[1]](diffhunk://#diff-9804e79782cec185c24bc24a0be1ce6b34c7caf33432c169cdc613ab49ca467bL89-R99) [[2]](diffhunk://#diff-9804e79782cec185c24bc24a0be1ce6b34c7caf33432c169cdc613ab49ca467bL108-R113) [[3]](diffhunk://#diff-9804e79782cec185c24bc24a0be1ce6b34c7caf33432c169cdc613ab49ca467bR803-R839)
* Fixed and refactored the logic for determining supported types for various data formats, ensuring more accurate type checks in helpers.

**Documentation:**

* Expanded `docs/Diagnostics.md` with detailed explanations and code examples for each new warning diagnostic (LIGHT_PROTO_W002 through LIGHT_PROTO_W013), including causes and lists of supported types.
* Minor update to an example to use `partial class` for consistency in documentation.