### PR TITLE
Remove --no-restore from build step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         run: dotnet restore
 
       - name: Build solution
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release
 
       - name: Run tests
         run: dotnet test --configuration Release --no-build --verbosity normal -p:PublishAot=false


### PR DESCRIPTION
The build step in the publish workflow no longer uses the --no-restore flag, ensuring that dependencies are restored during the build process.