### PR TITLE
Fix: publish protogen workflow

### DIFF
--- a/.github/workflows/publish-protogen.yml
+++ b/.github/workflows/publish-protogen.yml
@@ -52,7 +52,7 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: Run CodeGen tests
-        run: dotnet test tests/LightProto.ProtoGen.Tests/ --configuration Release --no-build --verbosity normal
+        run: dotnet test --project tests/LightProto.ProtoGen.Tests/ --configuration Release --no-build --verbosity normal
 
       - name: Resolve version
         id: version


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for publishing Protogen. The change clarifies the usage of the `dotnet test` command by explicitly specifying the test project with the `--project` flag.

* Updated the `dotnet test` command in `.github/workflows/publish-protogen.yml` to use the `--project` flag for specifying the test project, improving clarity and maintainability of the workflow.