### PR TITLE
Copilot/add readonlymemory support

### DIFF
--- a/src/LightProto.Generator/Helper.cs
+++ b/src/LightProto.Generator/Helper.cs
@@ -117,9 +117,19 @@ internal static class Helper
     {
         if (elementType.SpecialType == SpecialType.System_Byte && IsArrayType(type))
             return false;
+        if (IsReadOnlyMemoryType(type))
+            return true;
         var baseCollectionType = compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1")?.Construct(elementType)!;
         var conversion = compilation.ClassifyConversion(type, baseCollectionType);
         return conversion.IsImplicit;
+    }
+
+    internal static bool IsReadOnlyMemoryType(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol namedType)
+            return false;
+
+        return namedType.OriginalDefinition.ToDisplayString() == "System.ReadOnlyMemory<T>";
     }
 
     internal static bool IsStackType(ITypeSymbol type)

--- a/src/LightProto.Generator/Helper.cs
+++ b/src/LightProto.Generator/Helper.cs
@@ -66,7 +66,7 @@ internal static class Helper
             return true;
         }
 
-        return HasProperty(type, "Length", SpecialType.System_Int32);
+        return HasProperty(type, "Length", SpecialType.System_Int32) || HasProperty(type, "Length", SpecialType.System_Int64);
     }
 
     public static bool HasProperty(ITypeSymbol type, string name, SpecialType specialType)
@@ -117,7 +117,7 @@ internal static class Helper
     {
         if (elementType.SpecialType == SpecialType.System_Byte && IsArrayType(type))
             return false;
-        if (IsReadOnlyMemoryType(type))
+        if (IsReadOnlyMemoryType(type) || IsMemoryType(type) || IsReadOnlySequenceType(type))
             return true;
         var baseCollectionType = compilation.GetTypeByMetadataName("System.Collections.Generic.IEnumerable`1")?.Construct(elementType)!;
         var conversion = compilation.ClassifyConversion(type, baseCollectionType);
@@ -130,6 +130,22 @@ internal static class Helper
             return false;
 
         return namedType.OriginalDefinition.ToDisplayString() == "System.ReadOnlyMemory<T>";
+    }
+
+    internal static bool IsMemoryType(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol namedType)
+            return false;
+
+        return namedType.OriginalDefinition.ToDisplayString() == "System.Memory<T>";
+    }
+
+    internal static bool IsReadOnlySequenceType(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol namedType)
+            return false;
+
+        return namedType.OriginalDefinition.ToDisplayString() == "System.Buffers.ReadOnlySequence<T>";
     }
 
     internal static bool IsStackType(ITypeSymbol type)

--- a/src/LightProto.Generator/Helper.cs
+++ b/src/LightProto.Generator/Helper.cs
@@ -680,7 +680,13 @@ internal static class Helper
                     );
                     var fixedSize = GetFixedSize(elementType, format);
 
-                    if (!isPacked)
+                    if (
+                        !isPacked
+                        && !(
+                            elementType.SpecialType == SpecialType.System_Byte
+                            && (IsMemoryType(namedType) || IsReadOnlyMemoryType(namedType) || IsReadOnlySequenceType(namedType))
+                        )
+                    )
                     {
                         rawTag = ProtoMember.GetRawTag(fieldNumber, ProtoMember.GetPbWireType(compilation, elementType, format));
                     }

--- a/src/LightProto.Generator/ProtoMember.cs
+++ b/src/LightProto.Generator/ProtoMember.cs
@@ -165,14 +165,14 @@ internal class ProtoMember
 
         if (Helper.IsCollectionType(Compilation, Type) || Helper.IsDictionaryType(Compilation, Type))
         {
-            var check = Type.IsValueType ? "true" : $"{messageName}.{Name} != null";
+            var nullCheck = Type.IsValueType ? null : $"{messageName}.{Name} != null";
             if (Helper.HasCountProperty(Type))
             {
-                return $"{check} && {messageName}.{Name}.Count > 0";
+                return nullCheck is null ? $"{messageName}.{Name}.Count > 0" : $"{nullCheck} && {messageName}.{Name}.Count > 0";
             }
             if (Helper.HasLengthProperty(Type))
             {
-                return $"{check} && {messageName}.{Name}.Length > 0";
+                return nullCheck is null ? $"{messageName}.{Name}.Length > 0" : $"{nullCheck} && {messageName}.{Name}.Length > 0";
             }
         }
 

--- a/src/LightProto.Generator/ProtoMember.cs
+++ b/src/LightProto.Generator/ProtoMember.cs
@@ -163,15 +163,9 @@ internal class ProtoMember
             return "true";
         }
 
-        if (Type.IsValueType)
-        {
-            return $"{messageName}.{Name} != default";
-        }
-
-        var check = $"{messageName}.{Name} != null";
-
         if (Helper.IsCollectionType(Compilation, Type) || Helper.IsDictionaryType(Compilation, Type))
         {
+            var check = Type.IsValueType ? "true" : $"{messageName}.{Name} != null";
             if (Helper.HasCountProperty(Type))
             {
                 return $"{check} && {messageName}.{Name}.Count > 0";
@@ -182,6 +176,11 @@ internal class ProtoMember
             }
         }
 
-        return check;
+        if (Type.IsValueType)
+        {
+            return $"{messageName}.{Name} != default";
+        }
+
+        return $"{messageName}.{Name} != null";
     }
 }

--- a/src/LightProto/Parser/CollectionWriteHelper.cs
+++ b/src/LightProto/Parser/CollectionWriteHelper.cs
@@ -1,0 +1,42 @@
+namespace LightProto.Parser
+{
+    internal static class CollectionWriteHelper<T>
+    {
+        private static readonly bool ElementCanBeNull = default(T) is null;
+
+        public static long CalculateAllItemSize(ReadOnlySpan<T> values, IProtoWriter<T> itemWriter)
+        {
+            long size = 0;
+            foreach (var item in values)
+            {
+                ThrowIfNull(item);
+                size += itemWriter.CalculateLongMessageSize(item);
+            }
+            return size;
+        }
+
+        public static void WritePacked(ref WriterContext output, ReadOnlySpan<T> values, IProtoWriter<T> itemWriter)
+        {
+            foreach (var item in values)
+            {
+                itemWriter.WriteMessageTo(ref output, item);
+            }
+        }
+
+        public static void WriteUnpacked(ref WriterContext output, ReadOnlySpan<T> values, uint tag, IProtoWriter<T> itemWriter)
+        {
+            foreach (var item in values)
+            {
+                ThrowIfNull(item);
+                output.WriteTag(tag);
+                itemWriter.WriteMessageTo(ref output, item);
+            }
+        }
+
+        public static void ThrowIfNull(T item)
+        {
+            if (ElementCanBeNull && item is null)
+                throw new InvalidOperationException("Sequence contained null element");
+        }
+    }
+}

--- a/src/LightProto/Parser/Memory.cs
+++ b/src/LightProto/Parser/Memory.cs
@@ -1,12 +1,19 @@
 namespace LightProto.Parser
 {
-    public sealed class MemoryProtoWriter<T> : IProtoWriter, IProtoWriter<Memory<T>>
+    public sealed class MemoryProtoWriter<T> : IProtoWriter, IProtoWriter<Memory<T>>, ICollectionWriter
     {
         IProtoWriter<T> ItemWriter { get; }
-        uint Tag { get; }
+        uint Tag { get; set; }
         int ItemFixedSize { get; }
         static bool IsByte => typeof(T) == typeof(byte);
         bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
+        WireFormat.WireType ICollectionWriter.ItemWireType => IsByte ? WireFormat.WireType.LengthDelimited : ItemWriter.WireType;
+
+        uint ICollectionWriter.Tag
+        {
+            get => Tag;
+            set => Tag = value;
+        }
 
         public MemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
         {

--- a/src/LightProto/Parser/Memory.cs
+++ b/src/LightProto/Parser/Memory.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace LightProto.Parser
 {
     public sealed class MemoryProtoWriter<T> : IProtoWriter, IProtoWriter<Memory<T>>, ICollectionWriter
@@ -56,7 +58,7 @@ namespace LightProto.Parser
                 return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(dataSize) + dataSize;
             }
 
-            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value);
+            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value.Span);
         }
 
         public void WriteTo(ref WriterContext output, Memory<T> value)
@@ -66,7 +68,7 @@ namespace LightProto.Parser
 
             if (IsByte)
             {
-                var bytes = (Memory<byte>)(object)value;
+                var bytes = Unsafe.As<Memory<T>, Memory<byte>>(ref value);
                 output.WriteTag(Tag);
                 output.WriteLongLength(bytes.Length);
                 WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
@@ -79,37 +81,21 @@ namespace LightProto.Parser
                 output.WriteTag(Tag);
                 output.WriteLongLength(size);
 
-                foreach (var item in value.Span)
-                {
-                    ItemWriter.WriteMessageTo(ref output, item);
-                }
+                CollectionWriteHelper<T>.WritePacked(ref output, value.Span, ItemWriter);
                 return;
             }
 
-            foreach (var item in value.Span)
-            {
-                if (item is null)
-                    throw new Exception("Sequence contained null element");
-                output.WriteTag(Tag);
-                ItemWriter.WriteMessageTo(ref output, item);
-            }
+            CollectionWriteHelper<T>.WriteUnpacked(ref output, value.Span, Tag, ItemWriter);
         }
 
         private long CalculatePackedDataSize(Memory<T> value, int count)
         {
-            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value);
+            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value.Span);
         }
 
-        private long CalculateAllItemSize(Memory<T> value)
+        private long CalculateAllItemSize(ReadOnlySpan<T> values)
         {
-            long size = 0;
-            foreach (var item in value.Span)
-            {
-                if (item is null)
-                    throw new Exception("Sequence contained null element");
-                size += ItemWriter.CalculateLongMessageSize(item);
-            }
-            return size;
+            return CollectionWriteHelper<T>.CalculateAllItemSize(values, ItemWriter);
         }
     }
 
@@ -141,7 +127,8 @@ namespace LightProto.Parser
             {
                 var length = input.ReadLength();
                 var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
-                return (Memory<TItem>)(object)new Memory<byte>(bytes);
+                var result = new Memory<byte>(bytes);
+                return Unsafe.As<Memory<byte>, Memory<TItem>>(ref result);
             }
             return _arrayProtoReader.ParseFrom(ref input);
         }

--- a/src/LightProto/Parser/Memory.cs
+++ b/src/LightProto/Parser/Memory.cs
@@ -5,6 +5,7 @@ namespace LightProto.Parser
         IProtoWriter<T> ItemWriter { get; }
         uint Tag { get; }
         int ItemFixedSize { get; }
+        static bool IsByte => typeof(T) == typeof(byte);
         bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
 
         public MemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
@@ -37,6 +38,11 @@ namespace LightProto.Parser
             if (count == 0)
                 return 0;
 
+            if (IsByte)
+            {
+                return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(count) + count;
+            }
+
             if (IsPacked && PackedRepeated.Support<T>())
             {
                 var dataSize = CalculatePackedDataSize(value, count);
@@ -50,6 +56,15 @@ namespace LightProto.Parser
         {
             if (value.IsEmpty)
                 return;
+
+            if (IsByte)
+            {
+                var bytes = (Memory<byte>)(object)value;
+                output.WriteTag(Tag);
+                output.WriteLongLength(bytes.Length);
+                WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
+                return;
+            }
 
             if (IsPacked && PackedRepeated.Support<T>())
             {
@@ -96,10 +111,11 @@ namespace LightProto.Parser
         private readonly ArrayProtoReader<TItem> _arrayProtoReader;
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
+        static bool IsByte => typeof(TItem) == typeof(byte);
 
         object IProtoReader.ParseFrom(ref ReaderContext input) => ParseFrom(ref input);
 
-        public WireFormat.WireType ItemWireType => ItemReader.WireType;
+        public WireFormat.WireType ItemWireType => IsByte ? WireFormat.WireType.LengthDelimited : ItemReader.WireType;
         object ICollectionReader.Empty => Empty;
         public IProtoReader<TItem> ItemReader { get; }
 
@@ -114,6 +130,12 @@ namespace LightProto.Parser
 
         public Memory<TItem> ParseFrom(ref ReaderContext input)
         {
+            if (IsByte)
+            {
+                var length = input.ReadLength();
+                var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
+                return (Memory<TItem>)(object)new Memory<byte>(bytes);
+            }
             return _arrayProtoReader.ParseFrom(ref input);
         }
 

--- a/src/LightProto/Parser/Memory.cs
+++ b/src/LightProto/Parser/Memory.cs
@@ -1,0 +1,122 @@
+namespace LightProto.Parser
+{
+    public sealed class MemoryProtoWriter<T> : IProtoWriter, IProtoWriter<Memory<T>>
+    {
+        IProtoWriter<T> ItemWriter { get; }
+        uint Tag { get; }
+        int ItemFixedSize { get; }
+        bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
+
+        public MemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
+        {
+            ItemWriter = itemWriter;
+            Tag = tag;
+            ItemFixedSize = itemFixedSize;
+        }
+
+        public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+        public bool IsMessage => false;
+
+        int IProtoWriter.CalculateSize(object value) => CalculateSize((Memory<T>)value);
+
+        long IProtoWriter.CalculateLongSize(object value) => CalculateLongSize((Memory<T>)value);
+
+        void IProtoWriter.WriteTo(ref WriterContext output, object value) => WriteTo(ref output, (Memory<T>)value);
+
+        public int CalculateSize(Memory<T> value)
+        {
+            var size = CalculateLongSize(value);
+            if (size > int.MaxValue)
+                throw new OverflowException("Calculated size exceeds Int32.MaxValue");
+            return (int)size;
+        }
+
+        public long CalculateLongSize(Memory<T> value)
+        {
+            var count = value.Length;
+            if (count == 0)
+                return 0;
+
+            if (IsPacked && PackedRepeated.Support<T>())
+            {
+                var dataSize = CalculatePackedDataSize(value, count);
+                return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(dataSize) + dataSize;
+            }
+
+            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value);
+        }
+
+        public void WriteTo(ref WriterContext output, Memory<T> value)
+        {
+            if (value.IsEmpty)
+                return;
+
+            if (IsPacked && PackedRepeated.Support<T>())
+            {
+                var size = CalculatePackedDataSize(value, value.Length);
+                output.WriteTag(Tag);
+                output.WriteLongLength(size);
+
+                foreach (var item in value.Span)
+                {
+                    ItemWriter.WriteMessageTo(ref output, item);
+                }
+                return;
+            }
+
+            foreach (var item in value.Span)
+            {
+                if (item is null)
+                    throw new Exception("Sequence contained null element");
+                output.WriteTag(Tag);
+                ItemWriter.WriteMessageTo(ref output, item);
+            }
+        }
+
+        private long CalculatePackedDataSize(Memory<T> value, int count)
+        {
+            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value);
+        }
+
+        private long CalculateAllItemSize(Memory<T> value)
+        {
+            long size = 0;
+            foreach (var item in value.Span)
+            {
+                if (item is null)
+                    throw new Exception("Sequence contained null element");
+                size += ItemWriter.CalculateLongMessageSize(item);
+            }
+            return size;
+        }
+    }
+
+    public sealed class MemoryProtoReader<TItem> : ICollectionReader<Memory<TItem>, TItem>
+    {
+        private readonly ArrayProtoReader<TItem> _arrayProtoReader;
+        public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+        public bool IsMessage => false;
+
+        object IProtoReader.ParseFrom(ref ReaderContext input) => ParseFrom(ref input);
+
+        public WireFormat.WireType ItemWireType => ItemReader.WireType;
+        object ICollectionReader.Empty => Empty;
+        public IProtoReader<TItem> ItemReader { get; }
+
+        public MemoryProtoReader(IProtoReader<TItem> itemReader, int itemFixedSize)
+        {
+            _arrayProtoReader = new ArrayProtoReader<TItem>(itemReader, itemFixedSize);
+            ItemReader = itemReader;
+        }
+
+        public MemoryProtoReader(IProtoReader<TItem> itemReader, uint tag, int itemFixedSize)
+            : this(itemReader, itemFixedSize) { }
+
+        public Memory<TItem> ParseFrom(ref ReaderContext input)
+        {
+            return _arrayProtoReader.ParseFrom(ref input);
+        }
+
+        public Memory<TItem> Empty => Memory<TItem>.Empty;
+    }
+}

--- a/src/LightProto/Parser/ReadOnlyMemory.cs
+++ b/src/LightProto/Parser/ReadOnlyMemory.cs
@@ -1,12 +1,19 @@
 namespace LightProto.Parser
 {
-    public sealed class ReadOnlyMemoryProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlyMemory<T>>
+    public sealed class ReadOnlyMemoryProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlyMemory<T>>, ICollectionWriter
     {
         IProtoWriter<T> ItemWriter { get; }
-        uint Tag { get; }
+        uint Tag { get; set; }
         int ItemFixedSize { get; }
         static bool IsByte => typeof(T) == typeof(byte);
         bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
+        WireFormat.WireType ICollectionWriter.ItemWireType => IsByte ? WireFormat.WireType.LengthDelimited : ItemWriter.WireType;
+
+        uint ICollectionWriter.Tag
+        {
+            get => Tag;
+            set => Tag = value;
+        }
 
         public ReadOnlyMemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
         {

--- a/src/LightProto/Parser/ReadOnlyMemory.cs
+++ b/src/LightProto/Parser/ReadOnlyMemory.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace LightProto.Parser
 {
     public sealed class ReadOnlyMemoryProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlyMemory<T>>, ICollectionWriter
@@ -56,7 +58,7 @@ namespace LightProto.Parser
                 return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(dataSize) + dataSize;
             }
 
-            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value);
+            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value.Span);
         }
 
         public void WriteTo(ref WriterContext output, ReadOnlyMemory<T> value)
@@ -66,7 +68,7 @@ namespace LightProto.Parser
 
             if (IsByte)
             {
-                var bytes = (ReadOnlyMemory<byte>)(object)value;
+                var bytes = Unsafe.As<ReadOnlyMemory<T>, ReadOnlyMemory<byte>>(ref value);
                 output.WriteTag(Tag);
                 output.WriteLongLength(bytes.Length);
                 WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
@@ -79,37 +81,21 @@ namespace LightProto.Parser
                 output.WriteTag(Tag);
                 output.WriteLongLength(size);
 
-                foreach (var item in value.Span)
-                {
-                    ItemWriter.WriteMessageTo(ref output, item);
-                }
+                CollectionWriteHelper<T>.WritePacked(ref output, value.Span, ItemWriter);
                 return;
             }
 
-            foreach (var item in value.Span)
-            {
-                if (item is null)
-                    throw new Exception("Sequence contained null element");
-                output.WriteTag(Tag);
-                ItemWriter.WriteMessageTo(ref output, item);
-            }
+            CollectionWriteHelper<T>.WriteUnpacked(ref output, value.Span, Tag, ItemWriter);
         }
 
         private long CalculatePackedDataSize(ReadOnlyMemory<T> value, int count)
         {
-            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value);
+            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value.Span);
         }
 
-        private long CalculateAllItemSize(ReadOnlyMemory<T> value)
+        private long CalculateAllItemSize(ReadOnlySpan<T> values)
         {
-            long size = 0;
-            foreach (var item in value.Span)
-            {
-                if (item is null)
-                    throw new Exception("Sequence contained null element");
-                size += ItemWriter.CalculateLongMessageSize(item);
-            }
-            return size;
+            return CollectionWriteHelper<T>.CalculateAllItemSize(values, ItemWriter);
         }
     }
 
@@ -141,7 +127,8 @@ namespace LightProto.Parser
             {
                 var length = input.ReadLength();
                 var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
-                return (ReadOnlyMemory<TItem>)(object)new ReadOnlyMemory<byte>(bytes);
+                var result = new ReadOnlyMemory<byte>(bytes);
+                return Unsafe.As<ReadOnlyMemory<byte>, ReadOnlyMemory<TItem>>(ref result);
             }
             return _arrayProtoReader.ParseFrom(ref input);
         }

--- a/src/LightProto/Parser/ReadOnlyMemory.cs
+++ b/src/LightProto/Parser/ReadOnlyMemory.cs
@@ -1,17 +1,20 @@
-﻿using System.Runtime.InteropServices;
-
 namespace LightProto.Parser
 {
     public sealed class ReadOnlyMemoryProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlyMemory<T>>
     {
-        private readonly ArrayProtoWriter<T> _arrayProtoWriter;
+        IProtoWriter<T> ItemWriter { get; }
+        uint Tag { get; }
+        int ItemFixedSize { get; }
+        bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
 
         public ReadOnlyMemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
         {
-            _arrayProtoWriter = new ArrayProtoWriter<T>(itemWriter, tag, itemFixedSize);
+            ItemWriter = itemWriter;
+            Tag = tag;
+            ItemFixedSize = itemFixedSize;
         }
 
-        public WireFormat.WireType WireType => _arrayProtoWriter.WireType;
+        public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
 
         int IProtoWriter.CalculateSize(object value) => CalculateSize((ReadOnlyMemory<T>)value);
@@ -22,31 +25,69 @@ namespace LightProto.Parser
 
         public int CalculateSize(ReadOnlyMemory<T> value)
         {
-            return _arrayProtoWriter.CalculateSize(ToArray(value));
+            var size = CalculateLongSize(value);
+            if (size > int.MaxValue)
+                throw new OverflowException("Calculated size exceeds Int32.MaxValue");
+            return (int)size;
         }
 
         public long CalculateLongSize(ReadOnlyMemory<T> value)
         {
-            return _arrayProtoWriter.CalculateLongSize(ToArray(value));
+            var count = value.Length;
+            if (count == 0)
+                return 0;
+
+            if (IsPacked && PackedRepeated.Support<T>())
+            {
+                var dataSize = CalculatePackedDataSize(value, count);
+                return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(dataSize) + dataSize;
+            }
+
+            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value);
         }
 
         public void WriteTo(ref WriterContext output, ReadOnlyMemory<T> value)
         {
-            _arrayProtoWriter.WriteTo(ref output, ToArray(value));
+            if (value.IsEmpty)
+                return;
+
+            if (IsPacked && PackedRepeated.Support<T>())
+            {
+                var size = CalculatePackedDataSize(value, value.Length);
+                output.WriteTag(Tag);
+                output.WriteLongLength(size);
+
+                foreach (var item in value.Span)
+                {
+                    ItemWriter.WriteMessageTo(ref output, item);
+                }
+                return;
+            }
+
+            foreach (var item in value.Span)
+            {
+                if (item is null)
+                    throw new Exception("Sequence contained null element");
+                output.WriteTag(Tag);
+                ItemWriter.WriteMessageTo(ref output, item);
+            }
         }
 
-        private static T[] ToArray(ReadOnlyMemory<T> value)
+        private long CalculatePackedDataSize(ReadOnlyMemory<T> value, int count)
         {
-            if (value.IsEmpty)
-                return [];
-            if (MemoryMarshal.TryGetArray(value, out ArraySegment<T> segment))
+            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value);
+        }
+
+        private long CalculateAllItemSize(ReadOnlyMemory<T> value)
+        {
+            long size = 0;
+            foreach (var item in value.Span)
             {
-                if (segment.Array is null)
-                    return [];
-                if (segment.Offset == 0 && segment.Count == segment.Array.Length)
-                    return segment.Array;
+                if (item is null)
+                    throw new Exception("Sequence contained null element");
+                size += ItemWriter.CalculateLongMessageSize(item);
             }
-            return value.ToArray();
+            return size;
         }
     }
 

--- a/src/LightProto/Parser/ReadOnlyMemory.cs
+++ b/src/LightProto/Parser/ReadOnlyMemory.cs
@@ -1,0 +1,81 @@
+﻿using System.Runtime.InteropServices;
+
+namespace LightProto.Parser
+{
+    public sealed class ReadOnlyMemoryProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlyMemory<T>>
+    {
+        private readonly ArrayProtoWriter<T> _arrayProtoWriter;
+
+        public ReadOnlyMemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
+        {
+            _arrayProtoWriter = new ArrayProtoWriter<T>(itemWriter, tag, itemFixedSize);
+        }
+
+        public WireFormat.WireType WireType => _arrayProtoWriter.WireType;
+        public bool IsMessage => false;
+
+        int IProtoWriter.CalculateSize(object value) => CalculateSize((ReadOnlyMemory<T>)value);
+
+        long IProtoWriter.CalculateLongSize(object value) => CalculateLongSize((ReadOnlyMemory<T>)value);
+
+        void IProtoWriter.WriteTo(ref WriterContext output, object value) => WriteTo(ref output, (ReadOnlyMemory<T>)value);
+
+        public int CalculateSize(ReadOnlyMemory<T> value)
+        {
+            return _arrayProtoWriter.CalculateSize(ToArray(value));
+        }
+
+        public long CalculateLongSize(ReadOnlyMemory<T> value)
+        {
+            return _arrayProtoWriter.CalculateLongSize(ToArray(value));
+        }
+
+        public void WriteTo(ref WriterContext output, ReadOnlyMemory<T> value)
+        {
+            _arrayProtoWriter.WriteTo(ref output, ToArray(value));
+        }
+
+        private static T[] ToArray(ReadOnlyMemory<T> value)
+        {
+            if (value.IsEmpty)
+                return [];
+            if (MemoryMarshal.TryGetArray(value, out ArraySegment<T> segment))
+            {
+                if (segment.Array is null)
+                    return [];
+                if (segment.Offset == 0 && segment.Count == segment.Array.Length)
+                    return segment.Array;
+            }
+            return value.ToArray();
+        }
+    }
+
+    public sealed class ReadOnlyMemoryProtoReader<TItem> : ICollectionReader<ReadOnlyMemory<TItem>, TItem>
+    {
+        private readonly ArrayProtoReader<TItem> _arrayProtoReader;
+        public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+        public bool IsMessage => false;
+
+        object IProtoReader.ParseFrom(ref ReaderContext input) => ParseFrom(ref input);
+
+        public WireFormat.WireType ItemWireType => ItemReader.WireType;
+        object ICollectionReader.Empty => Empty;
+        public IProtoReader<TItem> ItemReader { get; }
+
+        public ReadOnlyMemoryProtoReader(IProtoReader<TItem> itemReader, int itemFixedSize)
+        {
+            _arrayProtoReader = new ArrayProtoReader<TItem>(itemReader, itemFixedSize);
+            ItemReader = itemReader;
+        }
+
+        public ReadOnlyMemoryProtoReader(IProtoReader<TItem> itemReader, uint tag, int itemFixedSize)
+            : this(itemReader, itemFixedSize) { }
+
+        public ReadOnlyMemory<TItem> ParseFrom(ref ReaderContext input)
+        {
+            return _arrayProtoReader.ParseFrom(ref input);
+        }
+
+        public ReadOnlyMemory<TItem> Empty => ReadOnlyMemory<TItem>.Empty;
+    }
+}

--- a/src/LightProto/Parser/ReadOnlyMemory.cs
+++ b/src/LightProto/Parser/ReadOnlyMemory.cs
@@ -5,6 +5,7 @@ namespace LightProto.Parser
         IProtoWriter<T> ItemWriter { get; }
         uint Tag { get; }
         int ItemFixedSize { get; }
+        static bool IsByte => typeof(T) == typeof(byte);
         bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
 
         public ReadOnlyMemoryProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
@@ -37,6 +38,11 @@ namespace LightProto.Parser
             if (count == 0)
                 return 0;
 
+            if (IsByte)
+            {
+                return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(count) + count;
+            }
+
             if (IsPacked && PackedRepeated.Support<T>())
             {
                 var dataSize = CalculatePackedDataSize(value, count);
@@ -50,6 +56,15 @@ namespace LightProto.Parser
         {
             if (value.IsEmpty)
                 return;
+
+            if (IsByte)
+            {
+                var bytes = (ReadOnlyMemory<byte>)(object)value;
+                output.WriteTag(Tag);
+                output.WriteLongLength(bytes.Length);
+                WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
+                return;
+            }
 
             if (IsPacked && PackedRepeated.Support<T>())
             {
@@ -96,10 +111,11 @@ namespace LightProto.Parser
         private readonly ArrayProtoReader<TItem> _arrayProtoReader;
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
+        static bool IsByte => typeof(TItem) == typeof(byte);
 
         object IProtoReader.ParseFrom(ref ReaderContext input) => ParseFrom(ref input);
 
-        public WireFormat.WireType ItemWireType => ItemReader.WireType;
+        public WireFormat.WireType ItemWireType => IsByte ? WireFormat.WireType.LengthDelimited : ItemReader.WireType;
         object ICollectionReader.Empty => Empty;
         public IProtoReader<TItem> ItemReader { get; }
 
@@ -114,6 +130,12 @@ namespace LightProto.Parser
 
         public ReadOnlyMemory<TItem> ParseFrom(ref ReaderContext input)
         {
+            if (IsByte)
+            {
+                var length = input.ReadLength();
+                var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
+                return (ReadOnlyMemory<TItem>)(object)new ReadOnlyMemory<byte>(bytes);
+            }
             return _arrayProtoReader.ParseFrom(ref input);
         }
 

--- a/src/LightProto/Parser/ReadOnlySequence.cs
+++ b/src/LightProto/Parser/ReadOnlySequence.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace LightProto.Parser
 {
@@ -77,7 +78,9 @@ namespace LightProto.Parser
                 {
                     if (segment.IsEmpty)
                         continue;
-                    WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, ((ReadOnlyMemory<byte>)(object)segment).Span);
+                    var segmentBytes = segment;
+                    var bytes = Unsafe.As<ReadOnlyMemory<T>, ReadOnlyMemory<byte>>(ref segmentBytes);
+                    WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
                 }
                 return;
             }
@@ -90,23 +93,14 @@ namespace LightProto.Parser
 
                 foreach (var item in value)
                 {
-                    foreach (var current in item.Span)
-                    {
-                        ItemWriter.WriteMessageTo(ref output, current);
-                    }
+                    CollectionWriteHelper<T>.WritePacked(ref output, item.Span, ItemWriter);
                 }
                 return;
             }
 
             foreach (var item in value)
             {
-                foreach (var current in item.Span)
-                {
-                    if (current is null)
-                        throw new Exception("Sequence contained null element");
-                    output.WriteTag(Tag);
-                    ItemWriter.WriteMessageTo(ref output, current);
-                }
+                CollectionWriteHelper<T>.WriteUnpacked(ref output, item.Span, Tag, ItemWriter);
             }
         }
 
@@ -120,12 +114,7 @@ namespace LightProto.Parser
             long size = 0;
             foreach (var item in value)
             {
-                foreach (var current in item.Span)
-                {
-                    if (current is null)
-                        throw new Exception("Sequence contained null element");
-                    size += ItemWriter.CalculateLongMessageSize(current);
-                }
+                size += CollectionWriteHelper<T>.CalculateAllItemSize(item.Span, ItemWriter);
             }
             return size;
         }
@@ -161,7 +150,8 @@ namespace LightProto.Parser
                 if (length == 0)
                     return default;
                 var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
-                return (ReadOnlySequence<TItem>)(object)new ReadOnlySequence<byte>(bytes);
+                var sequence = new ReadOnlySequence<byte>(bytes);
+                return Unsafe.As<ReadOnlySequence<byte>, ReadOnlySequence<TItem>>(ref sequence);
             }
 
             var array = _arrayProtoReader.ParseFrom(ref input);

--- a/src/LightProto/Parser/ReadOnlySequence.cs
+++ b/src/LightProto/Parser/ReadOnlySequence.cs
@@ -38,18 +38,10 @@ namespace LightProto.Parser
         {
             if (IsByte)
             {
-                long size = 0;
-                foreach (var segment in value)
-                {
-                    if (segment.IsEmpty)
-                        continue;
-                    var bytes = (ReadOnlyMemory<byte>)(object)segment;
-                    size +=
-                        CodedOutputStream.ComputeRawVarint32Size(Tag)
-                        + CodedOutputStream.ComputeLongLengthSize(bytes.Length)
-                        + bytes.Length;
-                }
-                return size;
+                var length = value.Length;
+                if (length == 0)
+                    return 0;
+                return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(length) + length;
             }
 
             var count = value.Length;
@@ -72,14 +64,13 @@ namespace LightProto.Parser
 
             if (IsByte)
             {
+                output.WriteTag(Tag);
+                output.WriteLongLength(value.Length);
                 foreach (var segment in value)
                 {
                     if (segment.IsEmpty)
                         continue;
-                    var bytes = (ReadOnlyMemory<byte>)(object)segment;
-                    output.WriteTag(Tag);
-                    output.WriteLongLength(bytes.Length);
-                    WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
+                    WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, ((ReadOnlyMemory<byte>)(object)segment).Span);
                 }
                 return;
             }
@@ -159,34 +150,11 @@ namespace LightProto.Parser
         {
             if (IsByte)
             {
-                var tag = input.state.lastTag;
-                var segments = new List<byte[]>();
-                int totalLength = 0;
-                do
-                {
-                    var length = input.ReadLength();
-                    var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
-                    segments.Add(bytes);
-                    checked
-                    {
-                        totalLength += bytes.Length;
-                    }
-                } while (ParsingPrimitives.MaybeConsumeTag(ref input.buffer, ref input.state, tag));
-
-                if (totalLength == 0)
+                var length = input.ReadLength();
+                if (length == 0)
                     return default;
-
-                if (segments.Count == 1)
-                    return (ReadOnlySequence<TItem>)(object)new ReadOnlySequence<byte>(segments[0]);
-
-                var combined = new byte[totalLength];
-                int offset = 0;
-                foreach (var segment in segments)
-                {
-                    Buffer.BlockCopy(segment, 0, combined, offset, segment.Length);
-                    offset += segment.Length;
-                }
-                return (ReadOnlySequence<TItem>)(object)new ReadOnlySequence<byte>(combined);
+                var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
+                return (ReadOnlySequence<TItem>)(object)new ReadOnlySequence<byte>(bytes);
             }
 
             var array = _arrayProtoReader.ParseFrom(ref input);

--- a/src/LightProto/Parser/ReadOnlySequence.cs
+++ b/src/LightProto/Parser/ReadOnlySequence.cs
@@ -1,0 +1,134 @@
+using System.Buffers;
+
+namespace LightProto.Parser
+{
+    public sealed class ReadOnlySequenceProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlySequence<T>>
+    {
+        IProtoWriter<T> ItemWriter { get; }
+        uint Tag { get; }
+        int ItemFixedSize { get; }
+        bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
+
+        public ReadOnlySequenceProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
+        {
+            ItemWriter = itemWriter;
+            Tag = tag;
+            ItemFixedSize = itemFixedSize;
+        }
+
+        public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+        public bool IsMessage => false;
+
+        int IProtoWriter.CalculateSize(object value) => CalculateSize((ReadOnlySequence<T>)value);
+
+        long IProtoWriter.CalculateLongSize(object value) => CalculateLongSize((ReadOnlySequence<T>)value);
+
+        void IProtoWriter.WriteTo(ref WriterContext output, object value) => WriteTo(ref output, (ReadOnlySequence<T>)value);
+
+        public int CalculateSize(ReadOnlySequence<T> value)
+        {
+            var size = CalculateLongSize(value);
+            if (size > int.MaxValue)
+                throw new OverflowException("Calculated size exceeds Int32.MaxValue");
+            return (int)size;
+        }
+
+        public long CalculateLongSize(ReadOnlySequence<T> value)
+        {
+            var count = value.Length;
+            if (count == 0)
+                return 0;
+
+            if (IsPacked && PackedRepeated.Support<T>())
+            {
+                var dataSize = CalculatePackedDataSize(value, count);
+                return CodedOutputStream.ComputeRawVarint32Size(Tag) + CodedOutputStream.ComputeLongLengthSize(dataSize) + dataSize;
+            }
+
+            return CodedOutputStream.ComputeRawVarint32Size(Tag) * count + CalculateAllItemSize(value);
+        }
+
+        public void WriteTo(ref WriterContext output, ReadOnlySequence<T> value)
+        {
+            if (value.IsEmpty)
+                return;
+
+            if (IsPacked && PackedRepeated.Support<T>())
+            {
+                var size = CalculatePackedDataSize(value, value.Length);
+                output.WriteTag(Tag);
+                output.WriteLongLength(size);
+
+                foreach (var item in value)
+                {
+                    foreach (var current in item.Span)
+                    {
+                        ItemWriter.WriteMessageTo(ref output, current);
+                    }
+                }
+                return;
+            }
+
+            foreach (var item in value)
+            {
+                foreach (var current in item.Span)
+                {
+                    if (current is null)
+                        throw new Exception("Sequence contained null element");
+                    output.WriteTag(Tag);
+                    ItemWriter.WriteMessageTo(ref output, current);
+                }
+            }
+        }
+
+        private long CalculatePackedDataSize(ReadOnlySequence<T> value, long count)
+        {
+            return ItemFixedSize != 0 ? ItemFixedSize * count : CalculateAllItemSize(value);
+        }
+
+        private long CalculateAllItemSize(ReadOnlySequence<T> value)
+        {
+            long size = 0;
+            foreach (var item in value)
+            {
+                foreach (var current in item.Span)
+                {
+                    if (current is null)
+                        throw new Exception("Sequence contained null element");
+                    size += ItemWriter.CalculateLongMessageSize(current);
+                }
+            }
+            return size;
+        }
+    }
+
+    public sealed class ReadOnlySequenceProtoReader<TItem> : ICollectionReader<ReadOnlySequence<TItem>, TItem>
+    {
+        private readonly ArrayProtoReader<TItem> _arrayProtoReader;
+        public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
+        public bool IsMessage => false;
+
+        object IProtoReader.ParseFrom(ref ReaderContext input) => ParseFrom(ref input);
+
+        public WireFormat.WireType ItemWireType => ItemReader.WireType;
+        object ICollectionReader.Empty => Empty;
+        public IProtoReader<TItem> ItemReader { get; }
+
+        public ReadOnlySequenceProtoReader(IProtoReader<TItem> itemReader, int itemFixedSize)
+        {
+            _arrayProtoReader = new ArrayProtoReader<TItem>(itemReader, itemFixedSize);
+            ItemReader = itemReader;
+        }
+
+        public ReadOnlySequenceProtoReader(IProtoReader<TItem> itemReader, uint tag, int itemFixedSize)
+            : this(itemReader, itemFixedSize) { }
+
+        public ReadOnlySequence<TItem> ParseFrom(ref ReaderContext input)
+        {
+            var array = _arrayProtoReader.ParseFrom(ref input);
+            return array.Length == 0 ? default : new ReadOnlySequence<TItem>(array);
+        }
+
+        public ReadOnlySequence<TItem> Empty => default;
+    }
+}

--- a/src/LightProto/Parser/ReadOnlySequence.cs
+++ b/src/LightProto/Parser/ReadOnlySequence.cs
@@ -7,6 +7,7 @@ namespace LightProto.Parser
         IProtoWriter<T> ItemWriter { get; }
         uint Tag { get; }
         int ItemFixedSize { get; }
+        static bool IsByte => typeof(T) == typeof(byte);
         bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
 
         public ReadOnlySequenceProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
@@ -35,6 +36,22 @@ namespace LightProto.Parser
 
         public long CalculateLongSize(ReadOnlySequence<T> value)
         {
+            if (IsByte)
+            {
+                long size = 0;
+                foreach (var segment in value)
+                {
+                    if (segment.IsEmpty)
+                        continue;
+                    var bytes = (ReadOnlyMemory<byte>)(object)segment;
+                    size +=
+                        CodedOutputStream.ComputeRawVarint32Size(Tag)
+                        + CodedOutputStream.ComputeLongLengthSize(bytes.Length)
+                        + bytes.Length;
+                }
+                return size;
+            }
+
             var count = value.Length;
             if (count == 0)
                 return 0;
@@ -52,6 +69,20 @@ namespace LightProto.Parser
         {
             if (value.IsEmpty)
                 return;
+
+            if (IsByte)
+            {
+                foreach (var segment in value)
+                {
+                    if (segment.IsEmpty)
+                        continue;
+                    var bytes = (ReadOnlyMemory<byte>)(object)segment;
+                    output.WriteTag(Tag);
+                    output.WriteLongLength(bytes.Length);
+                    WritingPrimitives.WriteRawBytes(ref output.buffer, ref output.state, bytes.Span);
+                }
+                return;
+            }
 
             if (IsPacked && PackedRepeated.Support<T>())
             {
@@ -107,10 +138,11 @@ namespace LightProto.Parser
         private readonly ArrayProtoReader<TItem> _arrayProtoReader;
         public WireFormat.WireType WireType => WireFormat.WireType.LengthDelimited;
         public bool IsMessage => false;
+        static bool IsByte => typeof(TItem) == typeof(byte);
 
         object IProtoReader.ParseFrom(ref ReaderContext input) => ParseFrom(ref input);
 
-        public WireFormat.WireType ItemWireType => ItemReader.WireType;
+        public WireFormat.WireType ItemWireType => IsByte ? WireFormat.WireType.LengthDelimited : ItemReader.WireType;
         object ICollectionReader.Empty => Empty;
         public IProtoReader<TItem> ItemReader { get; }
 
@@ -125,6 +157,38 @@ namespace LightProto.Parser
 
         public ReadOnlySequence<TItem> ParseFrom(ref ReaderContext input)
         {
+            if (IsByte)
+            {
+                var tag = input.state.lastTag;
+                var segments = new List<byte[]>();
+                int totalLength = 0;
+                do
+                {
+                    var length = input.ReadLength();
+                    var bytes = ParsingPrimitives.ReadRawBytes(ref input.buffer, ref input.state, length);
+                    segments.Add(bytes);
+                    checked
+                    {
+                        totalLength += bytes.Length;
+                    }
+                } while (ParsingPrimitives.MaybeConsumeTag(ref input.buffer, ref input.state, tag));
+
+                if (totalLength == 0)
+                    return default;
+
+                if (segments.Count == 1)
+                    return (ReadOnlySequence<TItem>)(object)new ReadOnlySequence<byte>(segments[0]);
+
+                var combined = new byte[totalLength];
+                int offset = 0;
+                foreach (var segment in segments)
+                {
+                    Buffer.BlockCopy(segment, 0, combined, offset, segment.Length);
+                    offset += segment.Length;
+                }
+                return (ReadOnlySequence<TItem>)(object)new ReadOnlySequence<byte>(combined);
+            }
+
             var array = _arrayProtoReader.ParseFrom(ref input);
             return array.Length == 0 ? default : new ReadOnlySequence<TItem>(array);
         }

--- a/src/LightProto/Parser/ReadOnlySequence.cs
+++ b/src/LightProto/Parser/ReadOnlySequence.cs
@@ -2,13 +2,20 @@ using System.Buffers;
 
 namespace LightProto.Parser
 {
-    public sealed class ReadOnlySequenceProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlySequence<T>>
+    public sealed class ReadOnlySequenceProtoWriter<T> : IProtoWriter, IProtoWriter<ReadOnlySequence<T>>, ICollectionWriter
     {
         IProtoWriter<T> ItemWriter { get; }
-        uint Tag { get; }
+        uint Tag { get; set; }
         int ItemFixedSize { get; }
         static bool IsByte => typeof(T) == typeof(byte);
         bool IsPacked => WireFormat.GetTagWireType(Tag) == WireFormat.WireType.LengthDelimited;
+        WireFormat.WireType ICollectionWriter.ItemWireType => IsByte ? WireFormat.WireType.LengthDelimited : ItemWriter.WireType;
+
+        uint ICollectionWriter.Tag
+        {
+            get => Tag;
+            set => Tag = value;
+        }
 
         public ReadOnlySequenceProtoWriter(IProtoWriter<T> itemWriter, uint tag, int itemFixedSize)
         {

--- a/src/LightProto/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/LightProto/PublicAPI/net/PublicAPI.Shipped.txt
@@ -245,6 +245,22 @@ LightProto.Parser.Matrix3x2ProtoParser
 LightProto.Parser.Matrix3x2ProtoParser.Matrix3x2ProtoParser() -> void
 LightProto.Parser.Matrix4x4ProtoParser
 LightProto.Parser.Matrix4x4ProtoParser.Matrix4x4ProtoParser() -> void
+LightProto.Parser.MemoryProtoReader<TItem>
+LightProto.Parser.MemoryProtoReader<TItem>.Empty.get -> System.Memory<TItem>
+LightProto.Parser.MemoryProtoReader<TItem>.IsMessage.get -> bool
+LightProto.Parser.MemoryProtoReader<TItem>.ItemReader.get -> LightProto.IProtoReader<TItem>!
+LightProto.Parser.MemoryProtoReader<TItem>.ItemWireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.MemoryProtoReader<TItem>.MemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoReader<TItem>.MemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, uint tag, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoReader<TItem>.ParseFrom(ref LightProto.ReaderContext input) -> System.Memory<TItem>
+LightProto.Parser.MemoryProtoReader<TItem>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.MemoryProtoWriter<T>
+LightProto.Parser.MemoryProtoWriter<T>.CalculateLongSize(System.Memory<T> value) -> long
+LightProto.Parser.MemoryProtoWriter<T>.CalculateSize(System.Memory<T> value) -> int
+LightProto.Parser.MemoryProtoWriter<T>.IsMessage.get -> bool
+LightProto.Parser.MemoryProtoWriter<T>.MemoryProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.MemoryProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.Memory<T> value) -> void
 LightProto.Parser.NullableProtoReader<T>
 LightProto.Parser.NullableProtoReader<T>.IsMessage.get -> bool
 LightProto.Parser.NullableProtoReader<T>.NullableProtoReader(LightProto.IProtoReader<T>! valueReader) -> void
@@ -307,6 +323,22 @@ LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.IsMessage.get -> bool
 LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.ReadOnlyMemoryProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
 LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
 LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.ReadOnlyMemory<T> value) -> void
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.Empty.get -> System.Buffers.ReadOnlySequence<TItem>
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ItemReader.get -> LightProto.IProtoReader<TItem>!
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ItemWireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ParseFrom(ref LightProto.ReaderContext input) -> System.Buffers.ReadOnlySequence<TItem>
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ReadOnlySequenceProtoReader(LightProto.IProtoReader<TItem>! itemReader, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ReadOnlySequenceProtoReader(LightProto.IProtoReader<TItem>! itemReader, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.CalculateLongSize(System.Buffers.ReadOnlySequence<T> value) -> long
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.CalculateSize(System.Buffers.ReadOnlySequence<T> value) -> int
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.ReadOnlySequenceProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.Buffers.ReadOnlySequence<T> value) -> void
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.Empty.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<TItem>!
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.IsMessage.get -> bool

--- a/src/LightProto/PublicAPI/net/PublicAPI.Shipped.txt
+++ b/src/LightProto/PublicAPI/net/PublicAPI.Shipped.txt
@@ -291,6 +291,22 @@ LightProto.Parser.ReadOnlyDictionaryProtoReader<TKey, TValue>.ReadOnlyDictionary
 LightProto.Parser.ReadOnlyDictionaryProtoReader<TKey, TValue>.WireType.get -> LightProto.WireFormat.WireType
 LightProto.Parser.ReadOnlyDictionaryProtoWriter<TKey, TValue>
 LightProto.Parser.ReadOnlyDictionaryProtoWriter<TKey, TValue>.ReadOnlyDictionaryProtoWriter(LightProto.IProtoWriter<TKey>! keyWriter, LightProto.IProtoWriter<TValue>! valueWriter, uint tag) -> void
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.Empty.get -> System.ReadOnlyMemory<TItem>
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ItemReader.get -> LightProto.IProtoReader<TItem>!
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ItemWireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ParseFrom(ref LightProto.ReaderContext input) -> System.ReadOnlyMemory<TItem>
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ReadOnlyMemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ReadOnlyMemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.CalculateLongSize(System.ReadOnlyMemory<T> value) -> long
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.CalculateSize(System.ReadOnlyMemory<T> value) -> int
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.ReadOnlyMemoryProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.ReadOnlyMemory<T> value) -> void
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.Empty.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<TItem>!
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.IsMessage.get -> bool

--- a/src/LightProto/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/LightProto/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -233,6 +233,22 @@ LightProto.Parser.ListProtoReader<T>.ListProtoReader(LightProto.IProtoReader<T>!
 LightProto.Parser.ListProtoReader<T>.ListProtoReader(LightProto.IProtoReader<T>! itemReader, uint tag, int itemFixedSize) -> void
 LightProto.Parser.ListProtoWriter<T>
 LightProto.Parser.ListProtoWriter<T>.ListProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoReader<TItem>
+LightProto.Parser.MemoryProtoReader<TItem>.Empty.get -> System.Memory<TItem>
+LightProto.Parser.MemoryProtoReader<TItem>.IsMessage.get -> bool
+LightProto.Parser.MemoryProtoReader<TItem>.ItemReader.get -> LightProto.IProtoReader<TItem>!
+LightProto.Parser.MemoryProtoReader<TItem>.ItemWireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.MemoryProtoReader<TItem>.MemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoReader<TItem>.MemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, uint tag, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoReader<TItem>.ParseFrom(ref LightProto.ReaderContext input) -> System.Memory<TItem>
+LightProto.Parser.MemoryProtoReader<TItem>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.MemoryProtoWriter<T>
+LightProto.Parser.MemoryProtoWriter<T>.CalculateLongSize(System.Memory<T> value) -> long
+LightProto.Parser.MemoryProtoWriter<T>.CalculateSize(System.Memory<T> value) -> int
+LightProto.Parser.MemoryProtoWriter<T>.IsMessage.get -> bool
+LightProto.Parser.MemoryProtoWriter<T>.MemoryProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.MemoryProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.MemoryProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.Memory<T> value) -> void
 LightProto.Parser.NullableProtoReader<T>
 LightProto.Parser.NullableProtoReader<T>.IsMessage.get -> bool
 LightProto.Parser.NullableProtoReader<T>.NullableProtoReader(LightProto.IProtoReader<T>! valueReader) -> void
@@ -291,6 +307,22 @@ LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.IsMessage.get -> bool
 LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.ReadOnlyMemoryProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
 LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
 LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.ReadOnlyMemory<T> value) -> void
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.Empty.get -> System.Buffers.ReadOnlySequence<TItem>
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ItemReader.get -> LightProto.IProtoReader<TItem>!
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ItemWireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ParseFrom(ref LightProto.ReaderContext input) -> System.Buffers.ReadOnlySequence<TItem>
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ReadOnlySequenceProtoReader(LightProto.IProtoReader<TItem>! itemReader, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.ReadOnlySequenceProtoReader(LightProto.IProtoReader<TItem>! itemReader, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlySequenceProtoReader<TItem>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.CalculateLongSize(System.Buffers.ReadOnlySequence<T> value) -> long
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.CalculateSize(System.Buffers.ReadOnlySequence<T> value) -> int
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.ReadOnlySequenceProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlySequenceProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.Buffers.ReadOnlySequence<T> value) -> void
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.Empty.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<TItem>!
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.IsMessage.get -> bool

--- a/src/LightProto/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/LightProto/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -275,6 +275,22 @@ LightProto.Parser.ReadOnlyDictionaryProtoReader<TKey, TValue>.ReadOnlyDictionary
 LightProto.Parser.ReadOnlyDictionaryProtoReader<TKey, TValue>.WireType.get -> LightProto.WireFormat.WireType
 LightProto.Parser.ReadOnlyDictionaryProtoWriter<TKey, TValue>
 LightProto.Parser.ReadOnlyDictionaryProtoWriter<TKey, TValue>.ReadOnlyDictionaryProtoWriter(LightProto.IProtoWriter<TKey>! keyWriter, LightProto.IProtoWriter<TValue>! valueWriter, uint tag) -> void
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.Empty.get -> System.ReadOnlyMemory<TItem>
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ItemReader.get -> LightProto.IProtoReader<TItem>!
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ItemWireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ParseFrom(ref LightProto.ReaderContext input) -> System.ReadOnlyMemory<TItem>
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ReadOnlyMemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.ReadOnlyMemoryProtoReader(LightProto.IProtoReader<TItem>! itemReader, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlyMemoryProtoReader<TItem>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.CalculateLongSize(System.ReadOnlyMemory<T> value) -> long
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.CalculateSize(System.ReadOnlyMemory<T> value) -> int
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.IsMessage.get -> bool
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.ReadOnlyMemoryProtoWriter(LightProto.IProtoWriter<T>! itemWriter, uint tag, int itemFixedSize) -> void
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WireType.get -> LightProto.WireFormat.WireType
+LightProto.Parser.ReadOnlyMemoryProtoWriter<T>.WriteTo(ref LightProto.WriterContext output, System.ReadOnlyMemory<T> value) -> void
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.Empty.get -> System.Collections.ObjectModel.ReadOnlyObservableCollection<TItem>!
 LightProto.Parser.ReadOnlyObservableCollectionProtoReader<TItem>.IsMessage.get -> bool

--- a/tests/LightProto.Tests/Parsers/MemoryBytesTests.cs
+++ b/tests/LightProto.Tests/Parsers/MemoryBytesTests.cs
@@ -1,0 +1,57 @@
+﻿using Google.Protobuf;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class MemoryBytesTests : BaseTests<MemoryBytesTests.Message, ByteArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public Memory<byte> Property { get; set; } = Memory<byte>.Empty;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new byte[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new byte[] { 0, 0, 0, 0, 0 } };
+        yield return new() { Property = new byte[] { 0 } };
+        yield return new() { Property = Memory<byte>.Empty };
+    }
+
+    public override IEnumerable<ByteArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ByteArrayTestsMessage() { Property = ByteString.CopyFrom(o.Property.ToArray()) });
+    }
+
+    public override async Task AssertGoogleResult(ByteArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToByteArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(bytes, new MemoryProtoReader<byte>(ByteProtoParser.ProtoReader, 0));
+        await Assert.That(deserialized.IsEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/MemoryPackedTests.cs
+++ b/tests/LightProto.Tests/Parsers/MemoryPackedTests.cs
@@ -1,0 +1,48 @@
+using LightProto;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class MemoryPackedTests : BaseTests<MemoryPackedTests.Message, ListPackedTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1, IsPacked = true)]
+        [ProtoBuf.ProtoMember(1, IsPacked = true)]
+        public Memory<int> Property { get; set; } = Memory<int>.Empty;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new int[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new int[] { -1, -2, -3, -4, -5 } };
+        yield return new() { Property = new int[] { 0, 0, 0, 0, 0 } };
+        yield return new() { Property = new int[] { 0 } };
+        yield return new() { Property = Memory<int>.Empty };
+    }
+
+    public override IEnumerable<ListPackedTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ListPackedTestsMessage() { Property = { o.Property.ToArray() } });
+    }
+
+    public override async Task AssertGoogleResult(ListPackedTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+}

--- a/tests/LightProto.Tests/Parsers/MemoryTests.cs
+++ b/tests/LightProto.Tests/Parsers/MemoryTests.cs
@@ -1,0 +1,57 @@
+﻿using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class MemoryTests : BaseTests<MemoryTests.Message, ArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public Memory<int> Property { get; set; } = Memory<int>.Empty;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new int[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new int[] { -1, -2, -3, -4, -5 } };
+        yield return new() { Property = new int[] { 0, 0, 0, 0, 0 } };
+        yield return new() { Property = new int[] { 0 } };
+        yield return new() { Property = Memory<int>.Empty };
+    }
+
+    public override IEnumerable<ArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ArrayTestsMessage() { Property = { o.Property.ToArray() } });
+    }
+
+    public override async Task AssertGoogleResult(ArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(bytes, new MemoryProtoReader<int>(Int32ProtoParser.ProtoReader, 0));
+        await Assert.That(deserialized.IsEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ReadOnlyMemoryBytesTests.cs
+++ b/tests/LightProto.Tests/Parsers/ReadOnlyMemoryBytesTests.cs
@@ -1,0 +1,57 @@
+﻿using Google.Protobuf;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ReadOnlyMemoryBytesTests : BaseTests<ReadOnlyMemoryBytesTests.Message, ByteArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ReadOnlyMemory<byte> Property { get; set; } = ReadOnlyMemory<byte>.Empty;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new byte[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new byte[] { 0, 0, 0, 0, 0 } };
+        yield return new() { Property = new byte[] { 0 } };
+        yield return new() { Property = ReadOnlyMemory<byte>.Empty };
+    }
+
+    public override IEnumerable<ByteArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ByteArrayTestsMessage() { Property = ByteString.CopyFrom(o.Property.ToArray()) });
+    }
+
+    public override async Task AssertGoogleResult(ByteArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property.ToByteArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(bytes, new ReadOnlyMemoryProtoReader<byte>(ByteProtoParser.ProtoReader, 0));
+        await Assert.That(deserialized.IsEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ReadOnlyMemoryTests.cs
+++ b/tests/LightProto.Tests/Parsers/ReadOnlyMemoryTests.cs
@@ -1,0 +1,57 @@
+﻿using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ReadOnlyMemoryTests : BaseTests<ReadOnlyMemoryTests.Message, ArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ReadOnlyMemory<int> Property { get; set; } = ReadOnlyMemory<int>.Empty;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new int[] { 1, 2, 3, 4, 5 } };
+        yield return new() { Property = new int[] { -1, -2, -3, -4, -5 } };
+        yield return new() { Property = new int[] { 0, 0, 0, 0, 0 } };
+        yield return new() { Property = new int[] { 0 } };
+        yield return new() { Property = ReadOnlyMemory<int>.Empty };
+    }
+
+    public override IEnumerable<ArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ArrayTestsMessage() { Property = { o.Property.ToArray() } });
+    }
+
+    public override async Task AssertGoogleResult(ArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(bytes, new ReadOnlyMemoryProtoReader<int>(Int32ProtoParser.ProtoReader, 0));
+        await Assert.That(deserialized.IsEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ReadOnlySequenceBytesTests.cs
+++ b/tests/LightProto.Tests/Parsers/ReadOnlySequenceBytesTests.cs
@@ -6,7 +6,7 @@ using LightProto.Parser;
 namespace LightProto.Tests.Parsers;
 
 [InheritsTests]
-public partial class ReadOnlySequenceBytesTests : BaseTests<ReadOnlySequenceBytesTests.Message, RepeatedBytesTestsMessage>
+public partial class ReadOnlySequenceBytesTests : BaseTests<ReadOnlySequenceBytesTests.Message, ByteArrayTestsMessage>
 {
     [ProtoContract]
     [ProtoBuf.ProtoContract]
@@ -62,27 +62,14 @@ public partial class ReadOnlySequenceBytesTests : BaseTests<ReadOnlySequenceByte
         yield return new() { Property = default };
     }
 
-    public override IEnumerable<RepeatedBytesTestsMessage> GetGoogleMessages()
+    public override IEnumerable<ByteArrayTestsMessage> GetGoogleMessages()
     {
-        return GetMessages()
-            .Select(o =>
-            {
-                var message = new RepeatedBytesTestsMessage();
-                foreach (var segment in o.Property)
-                {
-                    if (segment.IsEmpty)
-                        continue;
-                    message.Property.Add(ByteString.CopyFrom(segment.Span));
-                }
-                return message;
-            });
+        return GetMessages().Select(o => new ByteArrayTestsMessage() { Property = ByteString.CopyFrom(o.Property.ToArray()) });
     }
 
-    public override async Task AssertGoogleResult(RepeatedBytesTestsMessage clone, Message message)
+    public override async Task AssertGoogleResult(ByteArrayTestsMessage clone, Message message)
     {
-        var expected = message.Property.ToArray();
-        var actual = clone.Property.SelectMany(x => x.ToByteArray()).ToArray();
-        await Assert.That(actual).IsEquivalentTo(expected);
+        await Assert.That(clone.Property.ToByteArray()).IsEquivalentTo(message.Property.ToArray());
     }
 
     public override async Task AssertResult(Message clone, Message message)

--- a/tests/LightProto.Tests/Parsers/ReadOnlySequenceBytesTests.cs
+++ b/tests/LightProto.Tests/Parsers/ReadOnlySequenceBytesTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Buffers;
+using Google.Protobuf;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ReadOnlySequenceBytesTests : BaseTests<ReadOnlySequenceBytesTests.Message, RepeatedBytesTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ReadOnlySequence<byte> Property { get; set; } = default;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    class BufferSegment : ReadOnlySequenceSegment<byte>
+    {
+        public BufferSegment(byte[] memory)
+        {
+            Memory = memory;
+        }
+
+        public BufferSegment Append(byte[] memory)
+        {
+            var segment = new BufferSegment(memory) { RunningIndex = RunningIndex + Memory.Length };
+            Next = segment;
+            return segment;
+        }
+    }
+
+    static ReadOnlySequence<byte> CreateReadOnlySequence(params byte[][] segments)
+    {
+        if (segments.Length == 0)
+            return default;
+        var first = new BufferSegment(segments[0]);
+        var last = first;
+        for (int i = 1; i < segments.Length; i++)
+        {
+            last = last.Append(segments[i]);
+        }
+        return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 }) };
+        yield return new() { Property = CreateReadOnlySequence(new byte[] { 1, 2 }, new byte[] { 3, 4, 5 }) };
+        yield return new() { Property = new ReadOnlySequence<byte>(new byte[] { 0, 0, 0, 0, 0 }) };
+        yield return new() { Property = new ReadOnlySequence<byte>(new byte[] { 0 }) };
+        yield return new() { Property = default };
+    }
+
+    public override IEnumerable<RepeatedBytesTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages()
+            .Select(o =>
+            {
+                var message = new RepeatedBytesTestsMessage();
+                foreach (var segment in o.Property)
+                {
+                    if (segment.IsEmpty)
+                        continue;
+                    message.Property.Add(ByteString.CopyFrom(segment.Span));
+                }
+                return message;
+            });
+    }
+
+    public override async Task AssertGoogleResult(RepeatedBytesTestsMessage clone, Message message)
+    {
+        var expected = message.Property.ToArray();
+        var actual = clone.Property.SelectMany(x => x.ToByteArray()).ToArray();
+        await Assert.That(actual).IsEquivalentTo(expected);
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(bytes, new ReadOnlySequenceProtoReader<byte>(ByteProtoParser.ProtoReader, 0));
+        await Assert.That(deserialized.IsEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/ReadOnlySequenceTests.cs
+++ b/tests/LightProto.Tests/Parsers/ReadOnlySequenceTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Buffers;
+using LightProto;
+using LightProto.Parser;
+
+namespace LightProto.Tests.Parsers;
+
+[InheritsTests]
+public partial class ReadOnlySequenceTests : BaseTests<ReadOnlySequenceTests.Message, ArrayTestsMessage>
+{
+    [ProtoContract]
+    [ProtoBuf.ProtoContract]
+    public partial record Message
+    {
+        [ProtoMember(1)]
+        [ProtoBuf.ProtoMember(1)]
+        public ReadOnlySequence<int> Property { get; set; } = default;
+
+        public override string ToString()
+        {
+            return $"Property: {string.Join(", ", Property.ToArray())}";
+        }
+    }
+
+    protected override bool ProtoBuf_net_Serialize_Disabled { get; } = true;
+    protected override bool ProtoBuf_net_Deserialize_Disabled { get; } = true;
+
+    public override IEnumerable<Message> GetMessages()
+    {
+        yield return new() { Property = new ReadOnlySequence<int>(new int[] { 1, 2, 3, 4, 5 }) };
+        yield return new() { Property = new ReadOnlySequence<int>(new int[] { -1, -2, -3, -4, -5 }) };
+        yield return new() { Property = new ReadOnlySequence<int>(new int[] { 0, 0, 0, 0, 0 }) };
+        yield return new() { Property = new ReadOnlySequence<int>(new int[] { 0 }) };
+        yield return new() { Property = default };
+    }
+
+    public override IEnumerable<ArrayTestsMessage> GetGoogleMessages()
+    {
+        return GetMessages().Select(o => new ArrayTestsMessage() { Property = { o.Property.ToArray() } });
+    }
+
+    public override async Task AssertGoogleResult(ArrayTestsMessage clone, Message message)
+    {
+        await Assert.That(clone.Property).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    public override async Task AssertResult(Message clone, Message message)
+    {
+        await Assert.That(clone.Property.ToArray()).IsEquivalentTo(message.Property.ToArray());
+    }
+
+    [Test]
+    public async Task EmptyTest()
+    {
+        byte[] bytes = [];
+        var deserialized = Serializer.Deserialize(bytes, new ReadOnlySequenceProtoReader<int>(Int32ProtoParser.ProtoReader, 0));
+        await Assert.That(deserialized.IsEmpty).IsTrue();
+    }
+}

--- a/tests/LightProto.Tests/Parsers/parser.proto
+++ b/tests/LightProto.Tests/Parsers/parser.proto
@@ -7,6 +7,9 @@ import "protobuf-net/bcl.proto";
 message ByteArrayTestsMessage {
   bytes Property = 1;
 }
+message RepeatedBytesTestsMessage {
+  repeated bytes Property = 1;
+}
 message ArrayTestsMessage {
   repeated int32 Property = 1 [packed = false];
 }

--- a/tests/LightProto.Tests/Parsers/parser.proto
+++ b/tests/LightProto.Tests/Parsers/parser.proto
@@ -7,9 +7,6 @@ import "protobuf-net/bcl.proto";
 message ByteArrayTestsMessage {
   bytes Property = 1;
 }
-message RepeatedBytesTestsMessage {
-  repeated bytes Property = 1;
-}
 message ArrayTestsMessage {
   repeated int32 Property = 1 [packed = false];
 }

--- a/tests/LightProto.Tests/RuntimeParserTests.cs
+++ b/tests/LightProto.Tests/RuntimeParserTests.cs
@@ -19,6 +19,18 @@ public partial class RuntimeParserTests
         public int[] IntArray { get; set; } = [];
     }
 
+    [ProtoContract]
+    public partial class TestMemoryMessage
+    {
+        [ProtoMember(1)]
+        public byte[] Data { get; set; } = [];
+    }
+
+    public class RuntimeMemoryMessage
+    {
+        public Memory<byte> Data { get; set; } = Memory<byte>.Empty;
+    }
+
     [Test]
     public async Task RuntimeParser_Serialization_Deserialization_ProducesEquivalentResults()
     {
@@ -33,6 +45,35 @@ public partial class RuntimeParserTests
             Int32ProtoParser.ProtoWriter.GetCollectionWriter()
         );
         await RuntimeReaderWriter_ProducesEquivalentResults(runtimeParser.ProtoReader, runtimeParser.ProtoWriter);
+    }
+
+    [Test]
+    public async Task RuntimeWriter_MemoryByteMember_UsesSingleTag()
+    {
+        var protoReader = new RuntimeProtoReader<RuntimeMemoryMessage>(() => new());
+        protoReader.AddMember<Memory<byte>>(
+            1,
+            (message, value) => message.Data = value,
+            new MemoryProtoReader<byte>(ByteProtoParser.ProtoReader, 0)
+        );
+
+        var protoWriter = new RuntimeProtoWriter<RuntimeMemoryMessage>();
+        protoWriter.AddMember<Memory<byte>>(
+            1,
+            message => message.Data,
+            new MemoryProtoWriter<byte>(ByteProtoParser.ProtoWriter, WireFormat.MakeTag(1, WireFormat.WireType.LengthDelimited), 0)
+        );
+
+        var runtimeMessage = new RuntimeMemoryMessage { Data = new byte[] { 1, 2, 3, 4, 5 } };
+        var expectedMessage = new TestMemoryMessage { Data = [1, 2, 3, 4, 5] };
+
+        var runtimeBytes = runtimeMessage.ToByteArray(protoWriter);
+        var expectedBytes = expectedMessage.ToByteArray(TestMemoryMessage.ProtoWriter);
+
+        await Assert.That(runtimeBytes).IsEquivalentTo(expectedBytes);
+
+        var cloned = Serializer.Deserialize(runtimeBytes, protoReader);
+        await Assert.That(cloned.Data.ToArray()).IsEquivalentTo(runtimeMessage.Data.ToArray());
     }
 
     [Test]

--- a/tests/LightProto.Tests/RuntimeParserTests.cs
+++ b/tests/LightProto.Tests/RuntimeParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System.Buffers;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using LightProto.Parser;
 
@@ -29,6 +30,16 @@ public partial class RuntimeParserTests
     public class RuntimeMemoryMessage
     {
         public Memory<byte> Data { get; set; } = Memory<byte>.Empty;
+    }
+
+    public class RuntimeReadOnlyMemoryMessage
+    {
+        public ReadOnlyMemory<byte> Data { get; set; } = ReadOnlyMemory<byte>.Empty;
+    }
+
+    public class RuntimeReadOnlySequenceMessage
+    {
+        public ReadOnlySequence<byte> Data { get; set; } = ReadOnlySequence<byte>.Empty;
     }
 
     [Test]
@@ -74,6 +85,70 @@ public partial class RuntimeParserTests
 
         var cloned = Serializer.Deserialize(runtimeBytes, protoReader);
         await Assert.That(cloned.Data.ToArray()).IsEquivalentTo(runtimeMessage.Data.ToArray());
+    }
+
+    [Test]
+    public async Task RuntimeWriter_ReadOnlyMemoryByteMember_UsesSingleTag()
+    {
+        var protoReader = new RuntimeProtoReader<RuntimeReadOnlyMemoryMessage>(() => new());
+        protoReader.AddMember<ReadOnlyMemory<byte>>(
+            1,
+            (message, value) => message.Data = value,
+            new ReadOnlyMemoryProtoReader<byte>(ByteProtoParser.ProtoReader, 0)
+        );
+
+        var protoWriter = new RuntimeProtoWriter<RuntimeReadOnlyMemoryMessage>();
+        protoWriter.AddMember<ReadOnlyMemory<byte>>(
+            1,
+            message => message.Data,
+            new ReadOnlyMemoryProtoWriter<byte>(ByteProtoParser.ProtoWriter, WireFormat.MakeTag(1, WireFormat.WireType.LengthDelimited), 0)
+        );
+
+        var runtimeMessage = new RuntimeReadOnlyMemoryMessage { Data = new byte[] { 1, 2, 3, 4, 5 } };
+        var expectedMessage = new TestMemoryMessage { Data = [1, 2, 3, 4, 5] };
+
+        var runtimeBytes = runtimeMessage.ToByteArray(protoWriter);
+        var expectedBytes = expectedMessage.ToByteArray(TestMemoryMessage.ProtoWriter);
+
+        await Assert.That(runtimeBytes).IsEquivalentTo(expectedBytes);
+
+        var cloned = Serializer.Deserialize(runtimeBytes, protoReader);
+        await Assert.That(cloned.Data.ToArray()).IsEquivalentTo(runtimeMessage.Data.ToArray());
+    }
+
+    [Test]
+    public async Task RuntimeWriter_ReadOnlySequenceByteMember_UsesSingleTag()
+    {
+        var protoReader = new RuntimeProtoReader<RuntimeReadOnlySequenceMessage>(() => new());
+        protoReader.AddMember<ReadOnlySequence<byte>>(
+            1,
+            (message, value) => message.Data = value,
+            new ReadOnlySequenceProtoReader<byte>(ByteProtoParser.ProtoReader, 0)
+        );
+
+        var protoWriter = new RuntimeProtoWriter<RuntimeReadOnlySequenceMessage>();
+        protoWriter.AddMember<ReadOnlySequence<byte>>(
+            1,
+            message => message.Data,
+            new ReadOnlySequenceProtoWriter<byte>(
+                ByteProtoParser.ProtoWriter,
+                WireFormat.MakeTag(1, WireFormat.WireType.LengthDelimited),
+                0
+            )
+        );
+
+        var runtimeMessage = new RuntimeReadOnlySequenceMessage { Data = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5 }) };
+        var expectedMessage = new TestMemoryMessage { Data = [1, 2, 3, 4, 5] };
+
+        var runtimeBytes = runtimeMessage.ToByteArray(protoWriter);
+        var expectedBytes = expectedMessage.ToByteArray(TestMemoryMessage.ProtoWriter);
+
+        await Assert.That(runtimeBytes).IsEquivalentTo(expectedBytes);
+
+        var cloned = Serializer.Deserialize(runtimeBytes, protoReader);
+        var clonedData = new byte[cloned.Data.Length];
+        cloned.Data.CopyTo(clonedData);
+        await Assert.That(clonedData).IsEquivalentTo(new byte[] { 1, 2, 3, 4, 5 });
     }
 
     [Test]


### PR DESCRIPTION
This pr adds built in support for Memory/ReadOnlyMemory/ReadOnlySequence

Copilot using Codex 5.3 was the primary LLM used with human review and critique. 

I don't fully understand all of the reader/writer interfaces in this project, but the code seems to be functioning as expected